### PR TITLE
feat(hooks): add 5 core PreToolUse guardrail hooks

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,42 @@
+{
+  "description": "Standard tooling guardrails — mechanical enforcement of workflow rules that were previously documentation-only.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-raw-git-commit.sh",
+            "statusMessage": "Checking for raw git commit..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-raw-gh-pr-create.sh",
+            "statusMessage": "Checking for raw gh pr create..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-protected-branch-work.sh",
+            "statusMessage": "Checking branch protection..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-heredoc.sh",
+            "statusMessage": "Checking for heredoc syntax..."
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-memory-writes.sh",
+            "statusMessage": "Checking for MEMORY.md writes..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/scripts/block-heredoc.sh
+++ b/hooks/scripts/block-heredoc.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# block-heredoc.sh — PreToolUse hook for Bash.
+# Blocks heredoc syntax (<<EOF, <<'EOF', etc.) in shell commands.
+# Heredocs cause shell escaping failures with apostrophes, backticks,
+# and special characters. Write to a temp file and use --body-file instead.
+set -euo pipefail
+
+command=$(jq -r '.tool_input.command' < /dev/stdin)
+
+# Match heredoc operators: <<EOF, <<'EOF', <<"EOF", <<-EOF, etc.
+# But not << used in other contexts (e.g., bitshift in Python/etc.).
+if echo "$command" | grep -qE '<<-?\s*'\''?[A-Z_]+'\''?'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Heredoc syntax (<<EOF) is blocked. Write multi-line content to a temporary file and pass it via --body-file or --file instead."
+    }
+  }'
+else
+  exit 0
+fi

--- a/hooks/scripts/block-memory-writes.sh
+++ b/hooks/scripts/block-memory-writes.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# block-memory-writes.sh — PreToolUse hook for Write|Edit.
+# Blocks writes to MEMORY.md. All behavioral rules belong in managed,
+# version-controlled documentation (CLAUDE.md, AGENTS.md, skills, or docs/).
+set -euo pipefail
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.file // ""')
+
+if echo "$file_path" | grep -qE '(^|/)MEMORY\.md$'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Writing to MEMORY.md is blocked. All behavioral rules belong in version-controlled documentation (CLAUDE.md, AGENTS.md, skills, or docs/). Discuss with the user what to capture and where."
+    }
+  }'
+else
+  exit 0
+fi

--- a/hooks/scripts/block-protected-branch-work.sh
+++ b/hooks/scripts/block-protected-branch-work.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# block-protected-branch-work.sh — PreToolUse hook for Bash.
+# Blocks commits on protected branches (main, develop).
+# Does NOT block branch operations (checkout, merge, push, pull, etc.).
+set -euo pipefail
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command')
+
+# Only check commands that could create commits on the current branch.
+# Allow git operations that don't create commits (checkout, push, pull, etc.).
+if ! echo "$command" | grep -qE '(^|[;&|]\s*)(git\s+commit|st-commit)(\s|$)'; then
+  exit 0
+fi
+
+# Check the current branch
+cwd=$(echo "$input" | jq -r '.cwd // "."')
+branch=$(git -C "$cwd" branch --show-current 2>/dev/null || echo "")
+
+if [ "$branch" = "main" ] || [ "$branch" = "develop" ]; then
+  jq -n --arg branch "$branch" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("Commits on protected branch \"\($branch)\" are blocked. Create a feature branch first: git checkout -b feature/<name>")
+    }
+  }'
+else
+  exit 0
+fi

--- a/hooks/scripts/block-raw-gh-pr-create.sh
+++ b/hooks/scripts/block-raw-gh-pr-create.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# block-raw-gh-pr-create.sh — PreToolUse hook for Bash.
+# Blocks raw 'gh pr create' commands. Use st-submit-pr instead.
+set -euo pipefail
+
+command=$(jq -r '.tool_input.command' < /dev/stdin)
+
+if echo "$command" | grep -qE '(^|[;&|]\s*)gh\s+pr\s+create(\s|$)'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Raw gh pr create is blocked. Use st-submit-pr instead. See docs/repository-standards.md for usage."
+    }
+  }'
+else
+  exit 0
+fi

--- a/hooks/scripts/block-raw-git-commit.sh
+++ b/hooks/scripts/block-raw-git-commit.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# block-raw-git-commit.sh — PreToolUse hook for Bash.
+# Blocks raw 'git commit' commands. Use st-commit instead.
+set -euo pipefail
+
+command=$(jq -r '.tool_input.command' < /dev/stdin)
+
+# Match git commit but not st-commit or git commit-related subcommands
+# that aren't actual commits (e.g., git commit-tree, git commit-graph).
+if echo "$command" | grep -qE '(^|[;&|]\s*)git\s+commit(\s|$)'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Raw git commit is blocked. Use st-commit instead. See docs/repository-standards.md for usage."
+    }
+  }'
+else
+  exit 0
+fi


### PR DESCRIPTION
# Pull Request

## Summary

- Implements P1 hooks: 5 PreToolUse guardrails that mechanically enforce workflow rules previously relying on CLAUDE.md prose

## Issue Linkage

- Ref #177

## Testing

- markdownlint

## Notes

- Tracks standard-tooling#177. This is the first functional PR in the plugin repo. Hooks tested locally with 13 pass/0 fail scenarios covering deny and allow paths for all 5 hooks.