### PR TITLE
feat(plugin): add self-hosted marketplace for plugin distribution

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "standard-tooling-marketplace",
+  "owner": {
+    "name": "wphillipmoore"
+  },
+  "metadata": {
+    "description": "Standard tooling plugin marketplace for all managed repositories."
+  },
+  "plugins": [
+    {
+      "name": "standard-tooling",
+      "source": ".",
+      "description": "Shared hooks, skills, agents, and commands for all managed repositories in the standard-tooling ecosystem."
+    }
+  ]
+}


### PR DESCRIPTION
# Pull Request

## Summary

- Adds self-hosted marketplace.json for plugin distribution to consuming repos

## Issue Linkage

- Ref #177

## Testing

- markdownlint

## Notes

- -