### PR TITLE
feat(hooks): PostToolUse file validation on Write|Edit

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -40,6 +40,16 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-on-edit.sh",
+            "statusMessage": "Validating edited file..."
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {

--- a/hooks/scripts/validate-markdown.sh
+++ b/hooks/scripts/validate-markdown.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# validate-markdown.sh — Validate a Markdown file.
+# Auto-fixes with markdownlint --fix, then checks for remaining issues.
+set -euo pipefail
+
+file="$1"
+errors=""
+
+# Required
+if ! command -v markdownlint &>/dev/null; then
+  echo "FATAL: markdownlint not found on PATH" >&2
+  exit 2
+fi
+
+# Auto-fix: markdownlint --fix
+markdownlint --fix "$file" 2>/dev/null || true
+
+# Check: markdownlint (remaining unfixable issues)
+if ! output=$(markdownlint "$file" 2>&1); then
+  errors+="$output"$'\n'
+fi
+
+if [[ -n "$errors" ]]; then
+  echo "$errors" >&2
+  exit 2
+fi

--- a/hooks/scripts/validate-on-edit.sh
+++ b/hooks/scripts/validate-on-edit.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# validate-on-edit.sh — PostToolUse hook for Write|Edit.
+# Dispatches per-language validation on the edited file. Auto-fixable issues
+# are fixed in place silently; unfixable issues block the agent (exit 2).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // .tool_input.file // ""')
+
+# Skip if no file path or file doesn't exist (deleted / virtual)
+if [[ -z "$file_path" || ! -f "$file_path" ]]; then
+  exit 0
+fi
+
+# Route by extension or path pattern to per-language validator
+validator=""
+case "$file_path" in
+  *.py)
+    validator="$SCRIPT_DIR/validate-python.sh"
+    ;;
+  *.sh)
+    validator="$SCRIPT_DIR/validate-shell.sh"
+    ;;
+  *.md)
+    validator="$SCRIPT_DIR/validate-markdown.sh"
+    ;;
+  *.yml | *.yaml)
+    validator="$SCRIPT_DIR/validate-yaml.sh"
+    ;;
+  *.toml)
+    validator="$SCRIPT_DIR/validate-toml.sh"
+    ;;
+  *)
+    # Check for extensionless shell scripts (scripts/bin/*, scripts/lib/*)
+    if echo "$file_path" | grep -qE '(^|/)scripts/(bin|lib)/'; then
+      validator="$SCRIPT_DIR/validate-shell.sh"
+    elif [[ -f "$file_path" ]] && head -1 "$file_path" | grep -qE '^#!.*\b(bash|sh)\b'; then
+      validator="$SCRIPT_DIR/validate-shell.sh"
+    else
+      exit 0
+    fi
+    ;;
+esac
+
+# Run the validator and capture output
+errors=""
+if ! errors=$("$validator" "$file_path" 2>&1); then
+  exit_code=$?
+  jq -n --arg ctx "FILE VALIDATION FAILED for ${file_path}:
+${errors}
+Fix the issues above before continuing." '{
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: $ctx
+    }
+  }'
+  exit "$exit_code"
+fi

--- a/hooks/scripts/validate-python.sh
+++ b/hooks/scripts/validate-python.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# validate-python.sh — Validate a Python file.
+# Auto-fixes with ruff, then checks for remaining issues with ruff, mypy, and ty.
+set -euo pipefail
+
+file="$1"
+errors=""
+
+# All tools are required — fail loudly if missing
+for tool in ruff mypy ty; do
+  if ! command -v "$tool" &>/dev/null; then
+    echo "FATAL: $tool not found on PATH" >&2
+    exit 2
+  fi
+done
+
+# Auto-fix: ruff check --fix + ruff format
+ruff check --fix --quiet "$file" 2>/dev/null || true
+ruff format --quiet "$file" 2>/dev/null || true
+
+# Check: ruff lint (remaining unfixable issues)
+if ! output=$(ruff check "$file" 2>&1); then
+  errors+="$output"$'\n'
+fi
+
+# Check: mypy
+if ! output=$(mypy "$file" 2>&1); then
+  errors+="$output"$'\n'
+fi
+
+# Check: ty
+if ! output=$(ty check "$file" 2>&1); then
+  errors+="$output"$'\n'
+fi
+
+if [[ -n "$errors" ]]; then
+  echo "$errors" >&2
+  exit 2
+fi

--- a/hooks/scripts/validate-shell.sh
+++ b/hooks/scripts/validate-shell.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# validate-shell.sh — Validate a shell script.
+# Auto-fixes with shfmt, then checks with shellcheck.
+set -euo pipefail
+
+file="$1"
+errors=""
+
+# Both tools are required
+if ! command -v shfmt &>/dev/null; then
+  echo "FATAL: shfmt not found on PATH" >&2
+  exit 2
+fi
+if ! command -v shellcheck &>/dev/null; then
+  echo "FATAL: shellcheck not found on PATH" >&2
+  exit 2
+fi
+
+# Auto-fix: shfmt
+shfmt -w "$file" 2>/dev/null || true
+
+# Check: shellcheck
+if ! output=$(shellcheck "$file" 2>&1); then
+  errors+="$output"$'\n'
+fi
+
+if [[ -n "$errors" ]]; then
+  echo "$errors" >&2
+  exit 2
+fi

--- a/hooks/scripts/validate-toml.sh
+++ b/hooks/scripts/validate-toml.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# validate-toml.sh — Validate a TOML file.
+# Auto-fixes with taplo fmt, then checks with taplo check.
+set -euo pipefail
+
+file="$1"
+errors=""
+
+# Required
+if ! command -v taplo &>/dev/null; then
+  echo "FATAL: taplo not found on PATH" >&2
+  exit 2
+fi
+
+# Auto-fix: taplo fmt
+taplo fmt "$file" 2>/dev/null || true
+
+# Check: taplo syntax check
+if ! output=$(taplo check "$file" 2>&1); then
+  errors+="$output"$'\n'
+fi
+
+if [[ -n "$errors" ]]; then
+  echo "$errors" >&2
+  exit 2
+fi

--- a/hooks/scripts/validate-yaml.sh
+++ b/hooks/scripts/validate-yaml.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# validate-yaml.sh — Validate a YAML file.
+# Runs yamllint, and actionlint for GitHub workflow files.
+set -euo pipefail
+
+file="$1"
+errors=""
+
+# Required
+if ! command -v yamllint &>/dev/null; then
+  echo "FATAL: yamllint not found on PATH" >&2
+  exit 2
+fi
+
+# Check: yamllint
+if ! output=$(yamllint "$file" 2>&1); then
+  errors+="$output"$'\n'
+fi
+
+# Check: actionlint for GitHub workflow files
+if echo "$file" | grep -qE '\.github/workflows/.*\.ya?ml$'; then
+  if ! command -v actionlint &>/dev/null; then
+    echo "FATAL: actionlint not found on PATH" >&2
+    exit 2
+  fi
+  if ! output=$(actionlint "$file" 2>&1); then
+    errors+="$output"$'\n'
+  fi
+fi
+
+if [[ -n "$errors" ]]; then
+  echo "$errors" >&2
+  exit 2
+fi


### PR DESCRIPTION
# Pull Request

## Summary

- Add PostToolUse hook on Write|Edit that dispatches per-language file validation immediately after edits. Auto-fixable issues are fixed in place; unfixable issues block the agent (exit 2). All tools required.

## Issue Linkage

- Fixes #11

## Testing

- markdownlint

## Notes

- Prerequisite: standard-tooling-docker#14 (tools now in dev containers)