### PR TITLE
fix(docs): fix markdownlint and structural check failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # standard-tooling-plugin
 
-Claude Code plugin for the standard-tooling ecosystem. Delivers shared hooks,
-skills, agents, and commands to all managed repositories.
+## Table of Contents
+
+- [Overview](#overview)
+- [What's Included](#whats-included)
+- [Installation](#installation)
+- [Plugin Namespace](#plugin-namespace)
 
 ## Overview
+
+Claude Code plugin for the standard-tooling ecosystem. Delivers shared hooks,
+skills, agents, and commands to all managed repositories.
 
 This plugin is the behavioral counterpart to the
 [standard-tooling](https://github.com/wphillipmoore/standard-tooling) Python
@@ -13,12 +20,12 @@ that enforces workflow compliance mechanically.
 
 ## What's Included
 
-| Component | Purpose |
-|-----------|---------|
-| **Hooks** | PreToolUse guardrails (block raw git commit, enforce branch rules, etc.) |
-| **Skills** | Shared workflow skills (commit, PR, release, publish, etc.) |
-| **Agents** | Bootstrap subagent for session-start context loading |
-| **Commands** | User-invokable slash commands |
+|Component|Purpose|
+|---|---|
+|**Hooks**|PreToolUse guardrails (block raw git commit, etc.)|
+|**Skills**|Shared workflow skills (commit, PR, release, etc.)|
+|**Agents**|Bootstrap subagent for session-start context|
+|**Commands**|User-invokable slash commands|
 
 ## Installation
 

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -13,18 +13,18 @@ that enforces workflow compliance mechanically.
 
 ## What's Included
 
-| Component | Purpose |
-|-----------|---------|
-| [Hooks](hooks/index.md) | PreToolUse/PostToolUse/Stop guardrails that enforce workflow rules |
-| [Skills](skills/index.md) | Shared workflow skills (commit, PR, release, publish, etc.) |
-| [Agents](agents/index.md) | Bootstrap subagent for session-start context loading |
+|Component|Purpose|
+|---|---|
+|[Hooks](hooks/index.md)|Pre/PostToolUse/Stop workflow guardrails|
+|[Skills](skills/index.md)|Shared workflow skills (commit, PR, etc.)|
+|[Agents](agents/index.md)|Bootstrap subagent for session context|
 
 ## Two-Repo Model
 
-| Repo | Delivers | Distribution |
-|------|----------|-------------|
-| `standard-tooling` | Python CLIs (`st-*`), bash validators, git hooks | PATH |
-| `standard-tooling-plugin` | Hooks, skills, agents, commands | Claude Code plugin |
+|Repo|Delivers|Distribution|
+|---|---|---|
+|`standard-tooling`|Python CLIs (`st-*`), validators|PATH|
+|`standard-tooling-plugin`|Hooks, skills, agents, commands|Claude Code plugin|
 
 These are complementary: the plugin tells Claude how to behave; PATH makes the
 tools available to run.


### PR DESCRIPTION
# Pull Request

## Summary

- Fix pre-existing markdown failures: compact table style (MD060), line length (MD013), and add Table of Contents to README.md. Cleans up develop so post-finalization validation passes.

## Issue Linkage

- Fixes #15

## Testing

- markdownlint

## Notes

- -