### PR TITLE
Skip Cargo.toml/Cargo.lock in generic TOML validation

### DIFF
--- a/hooks/scripts/validate-on-edit.sh
+++ b/hooks/scripts/validate-on-edit.sh
@@ -30,6 +30,11 @@ case "$file_path" in
     validator="$SCRIPT_DIR/validate-yaml.sh"
     ;;
   *.toml)
+    # Skip language-specific manifests — generic TOML tools don't understand
+    # their semantics (e.g. taplo can't validate Cargo.toml dependencies).
+    case "$(basename "$file_path")" in
+      Cargo.toml | Cargo.lock) exit 0 ;;
+    esac
     validator="$SCRIPT_DIR/validate-toml.sh"
     ;;
   *)


### PR DESCRIPTION
## Summary
- Skip `Cargo.toml` and `Cargo.lock` in `validate-on-edit.sh` TOML validation
- Generic TOML validators (taplo) cannot understand Rust-specific manifest semantics

## Test plan
- [ ] Edit a `Cargo.toml` in a Rust repo — verify PostToolUse hook exits silently
- [ ] Edit a regular `.toml` file — verify validation still runs

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)