### PR TITLE
feat: add CI workflows and rulesets

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "standard-tooling",
   "description": "Shared hooks, skills, agents, and commands for all managed repositories in the standard-tooling ecosystem.",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "wphillipmoore"
   },

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,24 @@
+name: CI (push)
+
+on:
+  push:
+    branches:
+      - 'feature/**'
+      - 'bugfix/**'
+      - 'hotfix/**'
+      - 'chore/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    with:
+      run-security: 'false'
+      run-release-gates: 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
     with:
       language: bash
+      semgrep-language: ci
       run-codeql: 'false'
       run-standards: ${{ inputs.run-release-gates || 'true' }}
       run-security: ${{ inputs.run-security || 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Run markdownlint
-        run: markdown-standards
+        run: markdownlint 'docs/site/**/*.md' 'README.md'
 
   mkdocs-build:
     name: "ci: mkdocs-build"
@@ -79,7 +79,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.1
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
     with:
       language: bash
       run-codeql: 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,120 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_call:
+    inputs:
+      run-security:
+        type: string
+        default: 'true'
+      run-release-gates:
+        type: string
+        default: 'true'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  # ---------------------------------------------------------------------------
+  # Quality: shellcheck, markdownlint, mkdocs-build
+  # ---------------------------------------------------------------------------
+
+  shellcheck:
+    name: "ci: shellcheck"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run shellcheck
+        run: |
+          files=$(find hooks/scripts -type f -name '*.sh' | sort)
+          if [ -n "$files" ]; then
+            echo "$files" | xargs shellcheck
+          else
+            echo "No shell scripts found."
+          fi
+
+  markdownlint:
+    name: "ci: markdownlint"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wphillipmoore/dev-python:3.14
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Run markdownlint
+        run: markdown-standards
+
+  mkdocs-build:
+    name: "ci: mkdocs-build"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install mkdocs-material
+        run: pip install mkdocs-material
+
+      - name: Build docs
+        run: mkdocs build --strict
+        working-directory: docs/site
+
+  # ---------------------------------------------------------------------------
+  # Security and standards (shared reusable workflow)
+  # ---------------------------------------------------------------------------
+
+  security-and-standards:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.1
+    with:
+      language: bash
+      run-codeql: 'false'
+      run-standards: ${{ inputs.run-release-gates || 'true' }}
+      run-security: ${{ inputs.run-security || 'true' }}
+    permissions:
+      contents: read
+      security-events: write
+
+  # ---------------------------------------------------------------------------
+  # Release gates (PR only)
+  # ---------------------------------------------------------------------------
+
+  release-gates:
+    name: "release: gates"
+    if: ${{ inputs.run-release-gates != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip on non-PR events
+        if: github.event_name != 'pull_request'
+        run: echo "Not a pull request; skipping release gates."
+
+      - name: Checkout code
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Mark workspace safe for git
+        if: github.event_name == 'pull_request'
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Version divergence gate (PRs targeting develop)
+        if: github.event_name == 'pull_request' && github.base_ref == 'develop'
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.1
+        with:
+          head-version-command: jq -r '.version' .claude-plugin/plugin.json
+          main-version-command: git show origin/main:.claude-plugin/plugin.json | jq -r '.version'


### PR DESCRIPTION
Fixes #20

## Summary

- Adds Tier 2 (push) and Tier 3 (PR) CI workflows matching the ecosystem pattern
- Jobs: shellcheck, markdownlint, mkdocs-build, security-and-standards (with CodeQL disabled for bash), release gates with version divergence
- Resolves concurrency deadlock between ci-push and ci workflows by using a distinct concurrency group prefix
- GitHub rulesets created: branch protection, CI gates, tag protection
- Auto-merge enabled

## Test plan

- [x] Tier 2 push CI fires and passes (shellcheck, markdownlint, mkdocs-build)
- [x] Security and release gates skipped on push
- [x] Tier 3 PR CI fires with all jobs
- [ ] All Tier 3 jobs pass after fixes