### PR TITLE
chore: install standard-tooling-plugin in its own repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "standard-tooling-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "wphillipmoore/standard-tooling-plugin"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "standard-tooling@standard-tooling-marketplace": true
+  }
+}


### PR DESCRIPTION
Fixes #21

## Summary

- Adds .claude/settings.json with the standard marketplace configuration
- The plugin repo now eats its own dogfood — hooks like block-raw-gh-pr-create.sh will fire when working in this repo

## Test plan

- [ ] CI passes
- [ ] Plugin hooks activate in new Claude Code sessions in this repo