### PR TITLE
ci: use dev-docs container for docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,18 +16,14 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
+    container: ghcr.io/wphillipmoore/dev-docs:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.1
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
         with:
           version-command: jq -r '.version | split(".") | .[0:2] | join(".")' .claude-plugin/plugin.json


### PR DESCRIPTION
# Pull Request

## Summary

- Switch docs workflow to run inside ghcr.io/wphillipmoore/dev-docs:latest container, removing the separate Python setup step and pinning docs-deploy to @develop.

## Issue Linkage

- Fixes #26

## Testing

- markdownlint

## Notes

- -