### PR TITLE
fix: add PreToolUse hook to block bash associative arrays

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -24,6 +24,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-heredoc.sh",
             "statusMessage": "Checking for heredoc syntax..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-associative-arrays.sh",
+            "statusMessage": "Checking for bash associative arrays..."
           }
         ]
       },

--- a/hooks/scripts/block-associative-arrays.sh
+++ b/hooks/scripts/block-associative-arrays.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# block-associative-arrays.sh — PreToolUse hook for Bash.
+# Blocks bash associative arrays (declare -A) which require bash 4.0+.
+# macOS ships bash 3.2 (GPLv2) and will not upgrade to GPLv3 versions.
+set -euo pipefail
+
+command=$(jq -r '.tool_input.command' < /dev/stdin)
+
+# Match declare with -A flag in any position (e.g., -A, -Ag, -rA, -gA).
+if echo "$command" | grep -qE 'declare\s+-[a-zA-Z]*A'; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Bash associative arrays (declare -A) are blocked. macOS ships bash 3.2 which does not support them (added in bash 4.0). Use parallel indexed arrays, case statements, or move the logic to Python instead."
+    }
+  }'
+else
+  exit 0
+fi


### PR DESCRIPTION
Fixes #28

## Summary

- Adds `block-associative-arrays.sh` PreToolUse hook that detects `declare -A` (and variants like `-Ag`, `-rA`) in Bash tool commands
- Blocks execution with a clear error explaining the macOS bash 3.2 constraint and suggesting alternatives (parallel arrays, case statements, Python)
- Catches `declare -A` in any context: standalone commands, heredocs, inline scripts

## Test plan

- [x] Hook blocks `declare -A mymap`
- [x] Hook blocks `declare -Ag mymap`
- [x] Hook allows normal commands through
- [x] Passes shellcheck