### PR TITLE
chore: rename dev-docs container reference to dev-base

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
   deploy:
     name: "deploy: docs"
     runs-on: ubuntu-latest
-    container: ghcr.io/wphillipmoore/dev-docs:latest
+    container: ghcr.io/wphillipmoore/dev-base:latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
# Pull Request

## Summary

- Rename dev-docs container reference to dev-base in docs CI

## Issue Linkage

- Closes #38

## Testing

- markdownlint

## Notes

- -