### PR TITLE
chore(release): bump plugin.json to 1.3.0 for first real release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "standard-tooling",
   "description": "Shared hooks, skills, agents, and commands for all managed repositories in the standard-tooling ecosystem.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "wphillipmoore"
   },


### PR DESCRIPTION
# Pull Request

## Summary

- Bump plugin.json version 1.2.0 -> 1.3.0 on develop ahead of the first real v1.3.0 release from main. Cache-invalidation prep; no behavior change.

## Issue Linkage

- Ref #49

## Testing

- markdownlint

## Notes

- Small mechanical prep for the plugin#49 release. Pre-release bump on develop so when we merge develop -> main, publish.yml reads 1.3.0 from plugin.json and tags accordingly. Dogfooded the worktree convention.