### PR TITLE
fix(marketplace): pin consumers to main ref in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,8 @@
       "name": "standard-tooling",
       "source": {
         "source": "url",
-        "url": "https://github.com/wphillipmoore/standard-tooling-plugin.git"
+        "url": "https://github.com/wphillipmoore/standard-tooling-plugin.git",
+        "ref": "main"
       },
       "description": "Shared hooks, skills, agents, and commands for all managed repositories in the standard-tooling ecosystem."
     }


### PR DESCRIPTION
# Pull Request

## Summary

- pin plugin marketplace entry to main ref

## Issue Linkage

- Fixes #64

## Testing

- markdownlint

## Notes

- ## What

Add `"ref": "main"` to the plugin source in `.claude-plugin/marketplace.json`.

## Why

An unpinned URL source resolves to the repo's default branch (`develop`),
so every consumer pulling from this marketplace has been tracking
pre-release work instead of the last tagged release. The intended
behavior is: `main` is the release branch, and consumers should get
what was just tagged by `publish.yml`.

Caught on 2026-04-23 while verifying the v1.3.0 release. The plugin
cache kept showing develop-tip content (e.g. still including
`block-memory-writes.sh`) instead of the tagged main state.

## Docs reference

https://code.claude.com/docs/en/plugin-marketplaces — "You can pin to
a specific branch, tag, or commit."

## Verification plan

- Land this PR
- Cut v1.3.1 (already bumped on develop from the #63 back-merge PR)
- After tag, refresh marketplace clone and restart Claude Code
- Confirm plugin cache path reflects the main-side version, not
  develop-side