### PR TITLE
chore(release): close v1.4.1 cycle, bump plugin.json to 1.4.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "standard-tooling",
   "description": "Shared hooks, skills, agents, and commands for all managed repositories in the standard-tooling ecosystem.",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "wphillipmoore"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [1.4.0] - 2026-04-24
+## [1.4.1] - 2026-04-24
 
-### Features
+### Bug fixes
 
-- rewrite publish skill for poll-and-merge; bump composite pins to v1.2; plugin 1.4.0 (#70)
+- pass version-replacement to version-bump-pr composite; bump 1.4.1
+
+### Documentation
+
+- reorder publish skill phases so bump PR merge runs in parallel with slow publish
 
 ### Release
 
 - 1.3.0 (#62)
 - 1.3.1 (#67)
+
+## [1.4.0] - 2026-04-24
+
+### Features
+
+- rewrite publish skill for poll-and-merge; bump composite pins to v1.2; plugin 1.4.0 (#70)
 
 ## [1.3.1] - 2026-04-23
 

--- a/releases/v1.4.1.md
+++ b/releases/v1.4.1.md
@@ -1,0 +1,52 @@
+
+# Release 1.4.0 (2026-04-24)
+
+## Features
+
+- **rewrite publish skill for poll-and-merge; bump composite pins to v1.2; plugin 1.4.0 (#70)**
+Step 3 of 3 for the poll-and-merge rework (plugin#57).
+
+Three coordinated changes:
+
+## skills/publish/SKILL.md
+
+- New "Policy: agent-driven merges for release-workflow PRs"
+  section up front. Explicitly names the two PRs the agent is
+  allowed to merge (release PR and bump PR) and frames every
+  other PR as human-merged.
+- States that the release workflow is not complete until the bump
+  PR is merged — that step prepares the repo for the next cycle
+  and is part of this skill's responsibility.
+- Phase 2 was "Review and merge" (passive wait). Now "Merge
+  release PR": `st-docker-run -- st-merge-when-green <url>` with
+  explicit failure-propagation language.
+- Phase 4 was "Confirm version bump" (passive wait). Now "Merge
+  bump PR": poll for the `chore/bump-version-<next>` URL, then
+  `st-merge-when-green`. Callout that the bump PR is typically
+  green before the publish workflow run finishes, so Phase 4 can
+  overlap with Phase 3 verification.
+- TOC updated to match new headings.
+
+## .github/workflows/publish.yml
+
+- `tag-and-release` pin bumped `@v1.1` -> `@v1.2`.
+- `version-bump-pr` pin bumped `@v1.1` -> `@v1.2`. This is the
+  coordinated opt-in into the new "composite doesn't auto-merge;
+  skill does" behavior — must land together with the skill
+  rewrite, which is why it's in this same PR.
+
+## .claude-plugin/plugin.json
+
+- `1.3.2` -> `1.4.0`. Minor: behavior change in the skill; this
+  release is the fleet's opt-in trigger.
+
+## Verification
+
+This PR itself is a release-workflow dogfood:
+1. Manual review of the skill prose (no executable code beyond
+   workflow pin changes, which are mechanical).
+2. After merge, the v1.4.0 release cycle runs through the updated
+   publish.yml. That cycle will exercise both the new @v1.2
+   composite (creates but does not merge the bump PR) and the
+   new skill phases (agent merges both release PR and bump PR
+   via st-merge-when-green).


### PR DESCRIPTION
# Pull Request

## Summary

- close v1.4.1 cycle with manual bump to 1.4.2

## Issue Linkage

- Ref #77

## Testing

- markdownlint

## Notes

- ## What

Manual closure of the v1.4.1 release cycle.

- Back-merges `main` into `develop` (with `-X theirs`) to bring in
  the v1.4.1 `CHANGELOG.md` entry and `releases/v1.4.1.md`.
- Bumps `.claude-plugin/plugin.json` from `1.4.1` to `1.4.2`.

## Why

publish.yml's automated `version-bump-pr` step failed on the
v1.4.1 cycle due to the composite's bash/double-quote bug. That
composite bug is fixed in standard-actions v1.2.1 (#198 / #197),
which just released. `@v1.2` has now rolled forward and the
next publish.yml run will pick up the fix.

This PR gets develop back in sync so the next release (v1.4.2)
can proceed.

## Nature of merge

This is the agent-merged PR type per the publish skill's policy
(it fills in for the automated bump PR that didn't run). Using
`st-merge-when-green` after push.

## Related

- #77 — v1.4.1 release tracking issue (stays open until the
  v1.4.2 dogfood closes it out)
- wphillipmoore/standard-actions#197, #198 — the composite fix
- Same pattern as #63, #68, #74.