### PR TITLE
chore(migration): vendor .githooks gate + .yamllint (#89)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# pre-commit gate — admits st-commit-driven commits and legitimate
+# derived-commit workflows; rejects raw `git commit`.
+#
+# Source-of-truth contract: in standard-tooling
+# docs/specs/host-level-tool.md "Git hooks".
+# Companion: `git.run` in standard-tooling sets ST_COMMIT_CONTEXT=1
+# before invoking `git commit`.
+
+# Admit st-commit-driven commits. Print a diagnostic so the admission
+# is visible — this branch is also the documented escape hatch
+# (`ST_COMMIT_CONTEXT=1 git commit ...`) and any silent admit would
+# make manual workarounds invisible in the commit output.
+if [[ "${ST_COMMIT_CONTEXT:-}" == "1" ]]; then
+  echo "pre-commit gate: admitted (ST_COMMIT_CONTEXT=1)" >&2
+  exit 0
+fi
+
+# Admit derived-commit workflows that legitimately invoke `git commit`
+# without going through st-commit (amend, rebase, cherry-pick, revert,
+# merge-conflict resolution). GIT_REFLOG_ACTION is set by git itself.
+case "${GIT_REFLOG_ACTION:-}" in
+amend | cherry-pick | revert | rebase* | merge*)
+  echo "pre-commit gate: admitted (GIT_REFLOG_ACTION=${GIT_REFLOG_ACTION})" >&2
+  exit 0
+  ;;
+esac
+
+echo "ERROR: raw 'git commit' is blocked. Use 'st-commit' instead." >&2
+echo "See docs/repository-standards.md" >&2
+exit 1

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,43 @@
+# Canonical yamllint config for this repo.
+#
+# Vendored from standard-tooling for fleet consistency
+# (host-level-tool spec, Phase 6 migration; issue #89 / parent
+# standard-tooling#302). yamllint auto-discovers `.yamllint` in the
+# project root, so any local or CI yamllint run picks this up.
+#
+# Tuned for GitHub Actions workflow files and project YAML (mkdocs,
+# markdownlint, issue templates). Stricter rules would flag
+# pre-existing-and-fine content (e.g., GHA `on:` keys, long lines
+# carrying URLs or python-c expressions in workflow `run:` blocks),
+# turning every edit into a yak-shave. Where rules are relaxed below,
+# rationale is in-line.
+
+extends: default
+
+rules:
+  # GHA workflow files don't lead with `---`. Disabling rather than
+  # fighting the convention.
+  document-start: disable
+
+  # GHA's `on:` key is YAML's truthy-value (it parses as `True`). The
+  # default rule flags it; we exclude it. Other unintentional truthy
+  # values (yes/no/on/off) still flagged.
+  truthy:
+    allowed-values:
+      - "true"
+      - "false"
+    check-keys: false
+
+  # Per-rule ignore for `.github/workflows/`: workflows carry inline
+  # `python3 -c "..."` expressions as composite-action inputs (an
+  # unavoidable GHA pattern — input values must be single strings,
+  # can't be split across lines). The glob form matches both absolute
+  # and relative path invocations.
+  line-length:
+    max: 120
+    level: error
+    ignore: |
+      **/.github/workflows/**
+      .github/workflows/**
+
+  # Default trailing-spaces / empty-lines / etc. settings are fine.


### PR DESCRIPTION
# Pull Request

## Summary

- Phase 6 migration: vendor .githooks gate + .yamllint

## Issue Linkage

- Closes #89

## Testing

- markdownlint

## Notes

- Two additive changes — no stale CLAUDE.md / README / docs references to clean up. Scope is just vendoring the gate and the yamllint config; plugin-specific issues #87/#88/#69 remain separate.