### PR TITLE
fix(hooks): resolve session cwd and main repo root for worktree commits

### DIFF
--- a/hooks/scripts/block-protected-branch-work.sh
+++ b/hooks/scripts/block-protected-branch-work.sh
@@ -26,7 +26,14 @@ if ! echo "$command" | grep -qE '(^|[;&|]\s*)(git\s+commit|st-commit)(\s|$)'; th
   exit 0
 fi
 
-cwd=$(echo "$input" | jq -r '.tool_input.cwd // "."')
+# Resolve the bash session's working directory. Two fields can carry it:
+#   .tool_input.cwd  — set when the Bash tool call passes cwd explicitly.
+#   .cwd             — top-level hook input field; the session CWD that
+#                      Claude Code itself reports.
+# The current Bash tool typically populates the top-level `.cwd` only,
+# so falling back to "." (the previous behavior) misclassified every
+# commit as originating from the project root.
+cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
 
 # Determine the effective directory where the commit will actually run.
 # Handles two common patterns that redirect the commit to a different dir:
@@ -55,12 +62,25 @@ if [ -z "$toplevel" ]; then
   exit 0
 fi
 
+# When the commit is being made from inside a git worktree (not the main
+# checkout), `--show-toplevel` returns the worktree's own root, not the
+# main repo root. The worktree-convention check below needs the MAIN
+# repo root so it can match against `<main-root>/.worktrees/*`.
+# `--git-common-dir` points at the shared `.git` regardless of which
+# worktree we're in; its parent is the main repo root.
+git_common=$(git -C "$effective_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "")
+if [ -n "$git_common" ]; then
+  main_root=$(dirname "$git_common")
+else
+  main_root="$toplevel"
+fi
+
 # Has this repo adopted the worktree convention? Signal: a line reading
 # exactly `.worktrees/` in the repo-root .gitignore.
-if [ -f "$toplevel/.gitignore" ] && grep -qxF '.worktrees/' "$toplevel/.gitignore" 2>/dev/null; then
-  # Enforce: commit must originate from inside $toplevel/.worktrees/*.
+if [ -f "$main_root/.gitignore" ] && grep -qxF '.worktrees/' "$main_root/.gitignore" 2>/dev/null; then
+  # Enforce: commit must originate from inside $main_root/.worktrees/*.
   case "$effective_dir" in
-    "$toplevel"/.worktrees/*)
+    "$main_root"/.worktrees/*)
       exit 0
       ;;
     *)


### PR DESCRIPTION
# Pull Request

## Summary

- fix worktree CWD detection in block-protected-branch-work hook

## Issue Linkage

- Resolves #88

## Testing

- markdownlint

## Notes

- The hook had two bugs that compounded to deny every commit made from inside a git worktree:

1. It read `.tool_input.cwd` from the hook input JSON, which the current Claude Code Bash tool does not populate. Falling back to `"."` and resolving against the hook subprocess CWD (the project root) misclassified worktree commits as project-root commits.

2. `git rev-parse --show-toplevel` returns the worktree's own root inside a worktree, not the main repo root. The case match `"$toplevel"/.worktrees/*` then looked for a nested `.worktrees/` inside the worktree itself and never matched.

Either bug alone broke worktree commits; together they made the worktree convention unusable from agent sessions, forcing the `cd <abs-path> &&` prefix workaround documented in the issue.

## Changes

- Add `.cwd` to the jq fallback chain so the hook reads Claude Code's top-level session-CWD field.
- Use `git rev-parse --git-common-dir` to derive the main repo root (parent of the shared `.git`), regardless of which worktree the commit originates from.

## Verification

Empirical: hook input was captured by adding a temporary debug logger; `.cwd` reliably contains the bash session's CWD across Bash tool invocations. With both fixes applied, this PR's own commit succeeded from inside `.worktrees/issue-88-cwd-fallback/` without any `cd` prefix workaround.