### PR TITLE
docs(skills): split tool routing: release/git tools on host, validators in container

### DIFF
--- a/agents/bootstrap.md
+++ b/agents/bootstrap.md
@@ -48,18 +48,19 @@ If found, report: **st-docker-run: available.**
 If not found, report (and include the link verbatim so the user can
 open it):
 
-**WARNING: st-docker-run not found on PATH. This plugin's per-edit
-validation hooks will fail until it is installed. st-docker-run is the
-host-side dispatcher that runs commands inside the dev container image;
-it is delivered by the standard-tooling Python package. See the Getting
-Started guide for host venv bootstrap and PATH setup:
+**WARNING: st-docker-run not found on PATH. Validator dispatch
+(`st-validate-local`, dependency-update validation passes, and any
+container-routed lint/typecheck calls) will fail until it is installed.
+st-docker-run is the host-side dispatcher that runs language toolchain
+validators inside the dev container image; it is delivered by the
+standard-tooling Python package. See the Getting Started guide for host
+venv bootstrap and PATH setup:
 <https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/site/docs/getting-started.md>**
 
-This bootstrap check emits a warning (soft). Per-edit validation hooks
-treat the same missing dispatcher as a fatal error (hard) — the
-assumption is that the user has a chance to see this warning at session
-start; hooks that fire later stop quietly only after the warning has
-been ignored.
+Release-cycle tools (`st-commit`, `st-submit-pr`, `st-prepare-release`,
+`st-finalize-repo`, `st-merge-when-green`) run on the host and do not
+need st-docker-run — see [issue #96](https://github.com/wphillipmoore/standard-tooling-plugin/issues/96)
+for the host-vs-container split.
 
 ## 4. Standards and Conventions
 

--- a/skills/branch-workflow/SKILL.md
+++ b/skills/branch-workflow/SKILL.md
@@ -107,7 +107,7 @@ reference. The issue is likely a project-level parent. Treat it as Form 2
 Validate the issue exists:
 
 ```bash
-st-docker-run -- gh issue view <number> \
+gh issue view <number> \
   --repo <owner/repo> \
   --json number,title,state --jq '.'
 ```
@@ -124,7 +124,7 @@ Project issue URLs do not directly encode a repo issue number. Extract the
 item ID from the URL query parameter and resolve it:
 
 ```bash
-st-docker-run -- gh api graphql -f query='
+gh api graphql -f query='
 {
   node(id: "<item_node_id>") {
     ... on ProjectV2Item {
@@ -146,7 +146,7 @@ Note: The `itemId` in the URL is a **database ID** (integer), not the
 GraphQL node ID. Convert it first:
 
 ```bash
-st-docker-run -- gh api graphql -f query='
+gh api graphql -f query='
 {
   user(login: "<owner>") {
     projectV2(number: <project_number>) {
@@ -187,7 +187,7 @@ directory:
    of the parent:
 
    ```bash
-   st-docker-run -- gh api \
+   gh api \
      repos/<parent_owner>/<parent_repo>/issues/<parent_number>/sub_issues \
      --jq '.[] | select(.repository.full_name == "<current_repo>") | {number, title}'
    ```
@@ -197,7 +197,7 @@ directory:
 3. **If no sub-issue exists**, create one:
 
    ```bash
-   st-docker-run -- gh issue create \
+   gh issue create \
      --repo <current_repo> \
      --title "<parent_title>" \
      --body-file <tempfile>
@@ -215,12 +215,12 @@ directory:
 
    ```bash
    # Get the child issue's database ID
-   child_db_id=$(st-docker-run -- gh api \
+   child_db_id=$(gh api \
      repos/<current_owner>/<current_repo>/issues/<child_number> \
      --jq '.id')
 
    # Link to parent
-   st-docker-run -- gh api \
+   gh api \
      repos/<parent_owner>/<parent_repo>/issues/<parent_number>/sub_issues \
      --method POST -F sub_issue_id="$child_db_id"
    ```
@@ -228,7 +228,7 @@ directory:
 5. **Add to the project**. Determine which project the parent belongs to:
 
    ```bash
-   st-docker-run -- gh api graphql -f query='
+   gh api graphql -f query='
    {
      repository(owner: "<parent_owner>", name: "<parent_repo>") {
        issue(number: <parent_number>) {
@@ -248,7 +248,7 @@ directory:
    Add the new sub-issue to the same project:
 
    ```bash
-   st-docker-run -- gh project item-add <project_number> \
+   gh project item-add <project_number> \
      --owner <owner> \
      --url <child_issue_url> \
      --format json --jq '.id'

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -91,10 +91,12 @@ original event payload. Push a new commit to trigger a fresh workflow run.
 
 ## Finalization
 
-After the PR merges, run `st-docker-run -- st-finalize-repo` from the
-repository root. The tool switches to the target branch, fast-forward pulls
-from origin, deletes merged local branches, and prunes stale remotes. If
-`st-docker-run` is not available, perform the steps manually:
+After the PR merges, run `st-finalize-repo` from the repository root.
+The tool switches to the target branch, fast-forward pulls from origin,
+deletes merged local branches, and prunes stale remotes. `st-finalize-repo`
+is a host command — see [issue #96](https://github.com/wphillipmoore/standard-tooling-plugin/issues/96)
+for the host-vs-container split rationale. If it is not available,
+perform the steps manually:
 
 1. Switch to the target branch and pull latest from origin.
 2. Delete the local feature branch.

--- a/skills/project-issue/SKILL.md
+++ b/skills/project-issue/SKILL.md
@@ -90,13 +90,13 @@ If a command is not documented here, it is not needed.
 Determine the repository owner from the working directory:
 
 ```bash
-st-docker-run -- gh repo view --json owner --jq '.owner.login'
+gh repo view --json owner --jq '.owner.login'
 ```
 
 List available GitHub Projects:
 
 ```bash
-st-docker-run -- gh project list --owner <owner> \
+gh project list --owner <owner> \
   --format json \
   --jq '.projects[] | [.number, .title] | @tsv'
 ```
@@ -114,7 +114,7 @@ automatically and confirm.
 List the repositories linked to the selected project:
 
 ```bash
-st-docker-run -- st-list-project-repos --owner <owner> --project <project_number>
+st-list-project-repos --owner <owner> --project <project_number>
 ```
 
 Output is one `owner/repo` per line. Ask the user which repository the
@@ -140,7 +140,7 @@ Ask the user for the issue type:
 After the user selects, ensure the label exists:
 
 ```bash
-st-docker-run -- st-ensure-label --repo <target_repo> --label <label>
+st-ensure-label --repo <target_repo> --label <label>
 ```
 
 **Captures**: `label`, `title_prefix`.
@@ -259,7 +259,7 @@ After user approval, execute the following steps in order.
 **Step 1 — Create the issue.** Write the body to a temp file and create:
 
 ```bash
-st-docker-run -- gh issue create --repo <target_repo> \
+gh issue create --repo <target_repo> \
   --title "<title>" --label "<label>" \
   --body-file <tempfile>
 ```
@@ -269,7 +269,7 @@ Capture the issue URL from stdout.
 **Step 2 — Add to project.** Add the issue and capture the item ID:
 
 ```bash
-st-docker-run -- gh project item-add <project_number> \
+gh project item-add <project_number> \
   --owner <owner> --url <issue_url> \
   --format json --jq '.id'
 ```
@@ -277,7 +277,7 @@ st-docker-run -- gh project item-add <project_number> \
 **Step 3 — Set priority:**
 
 ```bash
-st-docker-run -- st-set-project-field \
+st-set-project-field \
   --owner <owner> --project <project_number> \
   --item <item_id> --field Priority \
   --value <priority>
@@ -286,7 +286,7 @@ st-docker-run -- st-set-project-field \
 **Step 4 — Set work type:**
 
 ```bash
-st-docker-run -- st-set-project-field \
+st-set-project-field \
   --owner <owner> --project <project_number> \
   --item <item_id> --field "Work Type" \
   --value <work_type>

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -50,46 +50,89 @@ This skill is not applicable to application repositories.
 
 ## Host vs container commands
 
-This skill runs on the **host**. Almost all commands run inside the dev
-container via `st-docker-run`, which mounts the repo at `/workspace` and
-passes through `GH_TOKEN` and other environment variables automatically.
+Tools fall into two families with different runtime locations. Honor the
+split — silently bypassing it (or silently containerizing tools that
+belong on the host) is what produced
+[issue #96](https://github.com/wphillipmoore/standard-tooling-plugin/issues/96):
+47 days of agents short-circuiting "container-first" guidance for release
+tools, hiding three layered infrastructure failures until the first
+agent followed the rule verbatim.
 
-**Host commands** — run directly:
+### Host commands — run directly
+
+The release / git workflow family. These need the host's SSH agent for
+`git push`, the host's git config, the host's `gh` token store, and
+one-shot invocation patterns where container startup is wasted overhead.
+Containerizing them required adding `openssh-client` and mounting
+`~/.ssh` and would still need agent-socket passthrough — every layer is
+a seam that can break.
 
 - `git` — local git operations (checkout, branch, fetch, pull, push)
+- `gh` — all GitHub CLI operations (issue/PR/release management)
+- `st-prepare-release`, `st-commit`, `st-submit-pr`, `st-finalize-repo`,
+  `st-merge-when-green` — release/PR lifecycle drivers
+- `st-docker-run` itself — the dispatcher that runs container commands
+- `git-cliff` — changelog generation
 
-**Container commands** — run via `st-docker-run`:
+### Container commands — run via `st-docker-run --`
 
-- `gh` — all GitHub CLI operations
-- `st-prepare-release`, `st-commit`, `st-submit-pr`, `st-finalize-repo`
-- Validation commands (e.g. `markdownlint .`)
+The language toolchain validators. These are the heavyweight per-language
+tools whose maintenance burden on macOS is exactly what `st-docker-run`
+exists to eliminate, and whose per-edit invocation amortizes container
+caching.
 
-To invoke a container command:
+- `ruff`, `mypy`, `ty`, `black`, `isort` (Python)
+- `markdownlint`, `st-markdown-standards` (Markdown)
+- `yamllint`, `actionlint` (YAML / GitHub workflows)
+- `shellcheck`, `shfmt` (shell)
+- Any other linter / formatter / type-checker pinned to a project's
+  toolchain
+
+### Test for borderline cases
+
+If you're unsure where a tool belongs: is it primarily a wrapper around a
+containerized language toolchain (→ container), or a thin Python/shell
+driver around git/gh/SSH-using operations (→ host)? `st-validate-local`
+itself is a host orchestrator that dispatches its inner validators into
+the container — host driver, container payloads.
+
+### Examples
+
+Host (no wrapping):
 
 ```bash
-st-docker-run -- st-prepare-release --issue <N>
-st-docker-run -- gh issue create --repo <repo> --title "..." --body-file /workspace/tmp.md
+st-prepare-release --issue <N>
+gh issue create --title "..." --body-file /tmp/release-notes.md
 ```
 
-### Locating st-docker-run
+Container (always via `st-docker-run --`):
 
-Search for `st-docker-run` in this order:
+```bash
+st-docker-run -- ruff check .
+st-docker-run -- markdownlint .
+```
 
-1. `../standard-tooling/.venv-host/bin/st-docker-run` (sibling checkout
-   with host venv)
-2. `st-docker-run` on PATH (already installed)
+### Locating standard-tooling host commands
 
-If neither is found, **abort** with a message directing the user to set up
-the host venv:
+The host commands above are installed by the standard-tooling host venv.
+Search for them in this order:
+
+1. `../standard-tooling/.venv-host/bin/<command>` (sibling checkout with
+   host venv) — preferred
+2. `<command>` on PATH (already installed system-wide)
+
+If a required command is missing, **abort** with a message directing the
+user to set up the host venv:
 
 ```text
-st-docker-run not found. Run the following one-time setup:
+standard-tooling host commands not found. Run the following one-time setup:
   cd ../standard-tooling
   UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
 ```
 
-Resolve `st-docker-run` once during preflight and use the resolved path
-for all subsequent container command invocations.
+Resolve once during preflight and use the resolved paths for all
+subsequent invocations. Do not mix host-PATH and venv-bin invocations
+within a single session.
 
 ## Preflight
 
@@ -101,8 +144,11 @@ for all subsequent container command invocations.
   not apply.
 - Confirm you are on the `develop` branch with a clean working tree.
 - Identify the canonical validation command from the repository profile.
-- Locate `st-docker-run` using the search algorithm above. If not found,
-  **abort** with setup instructions.
+- Locate the standard-tooling host commands using the search algorithm
+  above (at minimum: `st-prepare-release`, `st-merge-when-green`,
+  `st-finalize-repo`, `st-commit`, `st-submit-pr`, `gh`, `git-cliff`,
+  `st-docker-run`). If any required command is missing, **abort** with
+  setup instructions.
 - Verify `GH_TOKEN` is set in the environment. If not, **abort** with a
   message directing the user to set it.
 - **Library-release only**: Read the current version from the project manifest
@@ -176,7 +222,7 @@ and is part of this skill's responsibility.
    standards-compliance gate. Log all subsequent phase completions,
    issues encountered, and resolutions as comments on this issue to
    maintain a complete record of the publish operation.
-3. Run `st-docker-run -- st-prepare-release --issue <N>` from the
+3. Run `st-prepare-release --issue <N>` from the
    repository root on `develop`, passing the tracking issue number.
 4. The script creates a `release/<version>` branch, generates the
    changelog, pushes the branch, creates a PR to `main` (with
@@ -189,7 +235,7 @@ and is part of this skill's responsibility.
 
 ### Phase 2 — Merge release PR
 
-1. Run `st-docker-run -- st-merge-when-green <release-pr-url>`.
+1. Run `st-merge-when-green <release-pr-url>`.
    The tool polls CI and merges once all required checks pass
    (merge-commit strategy, delete branch on merge).
 2. If any CI check fails, `st-merge-when-green` exits non-zero.
@@ -216,7 +262,7 @@ behind external async work.
    `gh pr list --head chore/bump-version-<next> --json url`.
    Retry until it appears (typically within ~60 seconds of
    Phase 2 completing).
-2. Run `st-docker-run -- st-merge-when-green <bump-pr-url>`.
+2. Run `st-merge-when-green <bump-pr-url>`.
 3. If CI fails, follow the failure-handling procedure — do not
    retry or merge manually.
 4. Comment on the tracking issue with Phase 3 results (bump PR URL,
@@ -256,7 +302,7 @@ URL, list of artifacts confirmed).
 1. Close the tracking issue with a final summary comment covering all phases.
    All issue and PR references in the summary must be full URLs (not short
    `#N` references) so they are clickable in the terminal.
-2. Run `st-docker-run -- st-finalize-repo` to return to a clean `develop`
+2. Run `st-finalize-repo` to return to a clean `develop`
    branch. The script updates local `develop`, deletes merged branches, and
    prunes stale remotes. Run final validation to confirm a clean state.
 
@@ -274,7 +320,7 @@ URL, list of artifacts confirmed).
    [Dependency update categories](#dependency-update-categories)).
 3. Run full validation.
 4. Submit via `pr-workflow`.
-5. Run `st-docker-run -- st-finalize-repo` to return to a clean `develop`
+5. Run `st-finalize-repo` to return to a clean `develop`
    branch. The script updates local `develop`, deletes merged branches, and
    prunes stale remotes. Run final validation to confirm a clean state.
 


### PR DESCRIPTION
# Pull Request

## Summary

- split tool routing: release/git tools on host, validators in container (plugin-side)

## Issue Linkage

- Ref #96

## Testing

- markdownlint

## Notes

- Plugin-side implementation of the host-vs-container split decided in #96. The companion changes in standard-tooling (container-first guide, getting-started, validate-local docs) and the follow-ups (Trivy pipeline fix, cache-bust, hook-level enforcement) are tracked separately from this issue.

## What changed

### `skills/publish/SKILL.md` (full rewrite of routing section + phase commands)

- Rewrote the 'Host vs container commands' section as two families with a borderline-case test (thin git/gh driver vs language-toolchain wrapper).
- Listed concrete examples of each family.
- Updated 'Locating standard-tooling host commands' to apply to all host-installed st-* commands, not just `st-docker-run`.
- Updated preflight to enumerate the host commands it actually needs.
- Stripped `st-docker-run --` from invocations of `st-prepare-release`, `st-merge-when-green` (x2), and `st-finalize-repo` (x2) across phases 1, 2, 3, 6 and docs-only phase 2.

### `skills/pr-workflow/SKILL.md`

- Dropped `st-docker-run --` from the `st-finalize-repo` invocation in the Finalization section, with a link back to #96 for the rationale.

### `skills/branch-workflow/SKILL.md`

- Stripped `st-docker-run --` from 9 `gh` invocations (issue view, GraphQL queries, REST API calls, project commands).

### `skills/project-issue/SKILL.md`

- Stripped `st-docker-run --` from 8 host-tool invocations: `gh`, `st-list-project-repos`, `st-ensure-label`, `st-set-project-field`.

### `agents/bootstrap.md`

- Replaced the stale 'per-edit validation hooks will fail' warning text (those hooks were removed in #91) with an accurate description of what `st-docker-run` is needed for (validator dispatch, `st-validate-local`).
- Added an explicit note that release-cycle tools run on the host with no `st-docker-run` requirement.

## Verification

```bash
grep -rnE 'st-docker-run -- (gh|st-list-project-repos|st-ensure-label|st-set-project-field|st-finalize-repo|st-prepare-release|st-commit|st-submit-pr|st-merge-when-green|git-cliff)' --include='*.md' --include='*.json' --include='*.sh' .
# (no matches outside .worktrees/ and releases/)
```

Remaining `st-docker-run --` usages are confined to the publish skill's container-command examples (`ruff check .`, `markdownlint .`) which are correctly classified as container-side.

## Out of scope (covered by #96 follow-ups)

- Fix the `standard-tooling-docker` Trivy pipeline (47 days broken).
- Add a cache-bust mechanism to `st-docker-run` (compare local vs remote digest).
- Add hook-level enforcement that warns when an agent wraps a host-only tool in `st-docker-run --`.
- Mirror this rewrite in `standard-tooling`'s container-first guide.

## Why this is a blocker

Per #96: every active agent session was silently bypassing the documented rule. Bringing the spec into agreement with the working practice — and adding the enforcement follow-ups — is the prerequisite for restarting work on the rest of the open issues.