### PR TITLE
docs: document plugin update sequence in README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,3 +153,12 @@ markdownlint .
 
 **NEVER use raw `git commit`** — always use `st-commit`.
 **NEVER use raw `gh pr create`** — always use `st-submit-pr`.
+
+## Refreshing the plugin locally
+
+When the user asks how to refresh / update / reinstall this plugin
+after a new release, the canonical sequence is in the README's
+[Update section](README.md#update). Do **not** guess or improvise —
+the sequence is three steps (`marketplace update` → `update` →
+`reload-plugins`) and each is required. The non-interactive CLI
+form is `claude plugin update <plugin>@<marketplace>`.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ in every Claude Code session.
 
 - [What this plugin does](#what-this-plugin-does)
 - [Install](#install)
+- [Update](#update)
 - [Component inventory](#component-inventory)
 - [Plugin namespace](#plugin-namespace)
 - [Related repositories](#related-repositories)
@@ -63,6 +64,63 @@ session start.
 `st-commit`, `st-submit-pr`, `st-finalize-repo`, and friends from
 the standard-tooling Python package. Install those on your host
 PATH first — see the Getting Started guide above.
+
+## Update
+
+After a new release ships, refresh the local install with this
+three-step sequence. Each step is required — none of them are
+implied by the others.
+
+```text
+/plugin marketplace update standard-tooling-marketplace
+/plugin update standard-tooling@standard-tooling-marketplace
+/reload-plugins
+```
+
+What each step does:
+
+1. **`/plugin marketplace update <marketplace>`** — refreshes the
+   marketplace index only. It tells Claude Code that a new version
+   exists; it does **not** download the new version.
+2. **`/plugin update <plugin>@<marketplace>`** — installs the new
+   version into the local cache at
+   `~/.claude/plugins/cache/<plugin-id>/<version>/`. The previous
+   version stays on disk for 7 days as a grace window for
+   concurrent sessions, then is removed automatically.
+3. **`/reload-plugins`** — applies the new skills / hooks / agents
+   to the **current** Claude Code session without restarting.
+   Without this, the running session keeps using the old in-memory
+   plugin state.
+
+### Non-interactive form
+
+For scripts and one-liners (e.g., `claude` invocations from a
+deploy hook), the same install-side action runs as:
+
+```bash
+claude plugin update standard-tooling@standard-tooling-marketplace
+```
+
+After running it, any **new** Claude Code session you start picks
+up the new version automatically. Existing sessions still need
+`/reload-plugins`.
+
+### Verify the update
+
+```bash
+ls -1 ~/.claude/plugins/cache/standard-tooling-marketplace/standard-tooling/
+```
+
+You should see one directory per cached version. The newest
+version should match the latest tag on
+[GitHub Releases](https://github.com/wphillipmoore/standard-tooling-plugin/releases).
+
+### References
+
+Sourced from the official Claude Code documentation:
+
+- [Plugins reference — CLI commands](https://code.claude.com/docs/en/plugins-reference.md)
+- [Discover plugins — Apply changes without restarting](https://code.claude.com/docs/en/discover-plugins.md)
 
 ## Component inventory
 


### PR DESCRIPTION
# Pull Request

## Summary

- document plugin update sequence in README and CLAUDE.md

## Issue Linkage

- Resolves #101

## Testing

- markdownlint

## Notes

- Closes the documentation gap that produced the wrong-command suggestion during the v1.4.3 publish. Adds an Update section to the README right after Install, plus a short pointer in CLAUDE.md so agents working in this repo find the canonical sequence without improvising.

## What's documented

The three-step canonical sequence (each step is required, none are implied by the others):

1. `/plugin marketplace update <marketplace>` — refreshes the marketplace index only; does not download new versions.
2. `/plugin update <plugin>@<marketplace>` — installs the new version into `~/.claude/plugins/cache/<plugin-id>/<version>/`. Old versions stay 7 days as a grace window for concurrent sessions.
3. `/reload-plugins` — applies new skills/hooks/agents to the current Claude Code session without restarting.

Plus the non-interactive CLI form for scripts: `claude plugin update <plugin>@<marketplace>`.

## Sources cited

- Plugins reference: <https://code.claude.com/docs/en/plugins-reference.md>
- Discover plugins (apply changes without restarting): <https://code.claude.com/docs/en/discover-plugins.md>

## Why CLAUDE.md too

The user's specific complaint: 'I keep getting dubious suggestions from you about anything related to how Claude Code works locally.' Agents reading CLAUDE.md at session start now have a one-paragraph note telling them where the canonical sequence lives — `README.md#update` — and explicitly warning against guessing.