### PR TITLE
feat(hooks): gate enforcement hooks on managed-repo detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,14 @@ Sourced from the official Claude Code documentation:
 ### Hooks
 
 PreToolUse, PostToolUse, and Stop hooks that enforce guardrails
-mechanically.
+mechanically. Every hook below **except `block-heredoc`** is
+gated on a managed-repo check: a repo must contain either
+`docs/repository-standards.md` or `st-config.yaml` at its root for
+the hook to fire. In repos without either marker, the gated hooks
+short-circuit to a no-op so the plugin doesn't interfere with
+ad-hoc git work in unrelated repositories. See the
+[hooks reference](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md#managed-repo-gating)
+for the rationale.
 
 | Hook | Matcher | Purpose |
 |---|---|---|

--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -16,6 +16,30 @@ alike routinely drift from when enforcement is prose-only.
 Each entry below covers what the hook catches, why it exists, and how
 to achieve the intent correctly when the hook blocks you.
 
+## Managed-repo gating
+
+Every hook below **except `block-heredoc`** is gated on a
+managed-repo check. A repo is "managed" when either of these marker
+files exists at the repo root:
+
+- `docs/repository-standards.md` — the existing per-repo config
+- `st-config.yaml` — the future single-file config (transition target;
+  both are accepted during migration)
+
+When neither marker is present, the gated hooks short-circuit to a
+no-op so the plugin doesn't interfere with ad-hoc git work in
+unrelated repositories. Detection is a pure-shell walk up from the
+bash session's CWD looking for either marker, terminating at a
+`.git` boundary or the filesystem root. No `git` subprocess; the
+gate's overhead is a handful of `stat()` calls.
+
+`block-heredoc` is intentionally **not** gated — heredoc syntax in
+CLI invocations breaks unpredictably regardless of which repo
+you're in, so the rule is universal.
+
+See [issue #87](https://github.com/wphillipmoore/standard-tooling-plugin/issues/87)
+for the rationale.
+
 ## PreToolUse Hooks — Bash
 
 ### block-raw-git-commit

--- a/hooks/scripts/block-associative-arrays.sh
+++ b/hooks/scripts/block-associative-arrays.sh
@@ -2,9 +2,24 @@
 # block-associative-arrays.sh — PreToolUse hook for Bash.
 # Blocks bash associative arrays (declare -A) which require bash 4.0+.
 # macOS ships bash 3.2 (GPLv2) and will not upgrade to GPLv3 versions.
+#
+# Gated on managed-repo detection (#87): no-op in repos that lack
+# either docs/repository-standards.md or st-config.yaml. See
+# hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
-command=$(jq -r '.tool_input.command' < /dev/stdin)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
+
+if ! is_managed_repo "$cwd"; then
+  exit 0
+fi
+
+command=$(echo "$input" | jq -r '.tool_input.command')
 
 # Match declare with -A flag in any position (e.g., -A, -Ag, -rA, -gA).
 if echo "$command" | grep -qE 'declare\s+-[a-zA-Z]*A'; then

--- a/hooks/scripts/block-protected-branch-work.sh
+++ b/hooks/scripts/block-protected-branch-work.sh
@@ -15,9 +15,22 @@
 #
 # See wphillipmoore/standard-tooling/docs/specs/worktree-convention.md
 # for the adopted-convention rules.
+#
+# Gated on managed-repo detection (#87): no-op in repos that lack
+# either docs/repository-standards.md or st-config.yaml. See
+# hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
 input=$(cat)
+cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+if ! is_managed_repo "$cwd"; then
+  exit 0
+fi
+
 command=$(echo "$input" | jq -r '.tool_input.command')
 
 # Only check commands that could create commits on the current branch.

--- a/hooks/scripts/block-raw-gh-pr-create.sh
+++ b/hooks/scripts/block-raw-gh-pr-create.sh
@@ -1,9 +1,24 @@
 #!/usr/bin/env bash
 # block-raw-gh-pr-create.sh — PreToolUse hook for Bash.
 # Blocks raw 'gh pr create' commands. Use st-submit-pr instead.
+#
+# Gated on managed-repo detection (#87): no-op in repos that lack
+# either docs/repository-standards.md or st-config.yaml. See
+# hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
-command=$(jq -r '.tool_input.command' < /dev/stdin)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
+
+if ! is_managed_repo "$cwd"; then
+  exit 0
+fi
+
+command=$(echo "$input" | jq -r '.tool_input.command')
 
 if echo "$command" | grep -qE '(^|[;&|]\s*)gh\s+pr\s+create(\s|$)'; then
   jq -n '{

--- a/hooks/scripts/block-raw-git-commit.sh
+++ b/hooks/scripts/block-raw-git-commit.sh
@@ -1,9 +1,24 @@
 #!/usr/bin/env bash
 # block-raw-git-commit.sh — PreToolUse hook for Bash.
 # Blocks raw 'git commit' commands. Use st-commit instead.
+#
+# Gated on managed-repo detection (#87): no-op in repos that lack
+# either docs/repository-standards.md or st-config.yaml. See
+# hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
-command=$(jq -r '.tool_input.command' < /dev/stdin)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
+
+if ! is_managed_repo "$cwd"; then
+  exit 0
+fi
+
+command=$(echo "$input" | jq -r '.tool_input.command')
 
 # Match git commit but not st-commit or git commit-related subcommands
 # that aren't actual commits (e.g., git commit-tree, git commit-graph).

--- a/hooks/scripts/detect-deprecation-warnings.sh
+++ b/hooks/scripts/detect-deprecation-warnings.sh
@@ -2,9 +2,22 @@
 # detect-deprecation-warnings.sh — PostToolUse hook for Bash.
 # After test commands run, checks output for deprecation warnings and
 # reminds Claude to triage them using the deprecation-triage skill.
+#
+# Gated on managed-repo detection (#87): no-op in repos that lack
+# either docs/repository-standards.md or st-config.yaml. See
+# hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
 input=$(cat)
+cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+if ! is_managed_repo "$cwd"; then
+  exit 0
+fi
+
 command=$(echo "$input" | jq -r '.tool_input.command')
 response=$(echo "$input" | jq -r '.tool_response // ""')
 

--- a/hooks/scripts/lib/managed-repo-check.sh
+++ b/hooks/scripts/lib/managed-repo-check.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# managed-repo-check.sh — shared helper for plugin enforcement hooks.
+#
+# A "managed" repo is one configured to use standard-tooling. The signal
+# is the presence of either of two marker files at the repo root:
+#
+#   docs/repository-standards.md   — the existing per-repo config
+#   st-config.yaml                 — the future single-file config
+#                                    (transition target; both are
+#                                    accepted during migration)
+#
+# When neither marker is present, the plugin's enforcement hooks
+# short-circuit to a no-op so the plugin does not interfere with
+# ad-hoc git work in repositories that have not opted in.
+#
+# This file is meant to be `source`d, not executed directly.
+#
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+#   if ! is_managed_repo "$cwd"; then
+#     exit 0
+#   fi
+
+# is_managed_repo <starting-dir>
+#
+# Walks up from <starting-dir> looking for either marker file. Returns
+# 0 (true) if a marker is found, 1 (false) otherwise. Termination
+# conditions:
+#   1. A marker file is found    → return 0 (managed)
+#   2. A `.git` boundary is found (file or directory — both are valid
+#      since a worktree's `.git` is a file pointing at the main repo's
+#      git dir). The marker check has already failed at this level,
+#      so → return 1 (not managed).
+#   3. The walk reaches `/` or an empty path → return 1 (not managed).
+#
+# Implementation note: pure shell. No subprocess spawns (no `git`,
+# no `dirname`, no `realpath`). Each iteration is two `[ -f ]` and
+# one `[ -e ]` — sub-millisecond per call.
+is_managed_repo() {
+	local dir="${1:-$PWD}"
+
+	# Resolve relative paths against the hook subprocess's PWD.
+	case "$dir" in
+	/*) ;;
+	*) dir="$PWD/$dir" ;;
+	esac
+
+	while [ "$dir" != "/" ] && [ -n "$dir" ]; do
+		if [ -f "$dir/docs/repository-standards.md" ] || [ -f "$dir/st-config.yaml" ]; then
+			return 0
+		fi
+		if [ -e "$dir/.git" ]; then
+			return 1
+		fi
+		dir="${dir%/*}"
+	done
+
+	return 1
+}

--- a/hooks/scripts/remind-finalize.sh
+++ b/hooks/scripts/remind-finalize.sh
@@ -1,9 +1,22 @@
 #!/usr/bin/env bash
 # remind-finalize.sh — PostToolUse hook for Bash.
 # After st-submit-pr runs, reminds Claude to finalize after the PR merges.
+#
+# Gated on managed-repo detection (#87): no-op in repos that lack
+# either docs/repository-standards.md or st-config.yaml. See
+# hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
 input=$(cat)
+cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+if ! is_managed_repo "$cwd"; then
+  exit 0
+fi
+
 command=$(echo "$input" | jq -r '.tool_input.command')
 
 # Only trigger after st-submit-pr

--- a/hooks/scripts/stop-guard-finalization.sh
+++ b/hooks/scripts/stop-guard-finalization.sh
@@ -2,9 +2,21 @@
 # stop-guard-finalization.sh — Stop hook.
 # Prevents Claude from stopping if a PR was submitted but st-finalize-repo
 # was not run in this session. Checks the transcript for evidence.
+#
+# Gated on managed-repo detection (#87): no-op in repos that lack
+# either docs/repository-standards.md or st-config.yaml. See
+# hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
 input=$(cat)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+
+if ! is_managed_repo "$PWD"; then
+  exit 0
+fi
+
 stop_hook_active=$(echo "$input" | jq -r '.stop_hook_active // false')
 transcript_path=$(echo "$input" | jq -r '.transcript_path // ""')
 


### PR DESCRIPTION
# Pull Request

## Summary

- gate enforcement hooks on managed-repo detection

## Issue Linkage

- Resolves #87

## Testing

- markdownlint

## Notes

- Adds a shared `is_managed_repo` helper and gates every plugin hook (except `block-heredoc`) on its result. The plugin now stays out of the way in repos that haven't opted in to standard-tooling.

## Detection rule

A repo is "managed" if either marker exists at the repo root:

- `docs/repository-standards.md` — existing per-repo config
- `st-config.yaml` — future single-file config (transition target; both accepted during migration)

The check is a pure-shell upward walk from the bash session's CWD, terminating at a `.git` boundary or `/`. No `git` subprocess. Per-call cost is a handful of `stat()`s — sub-millisecond.

## Hooks

| Hook | Gate? |
|---|---|
| `block-raw-git-commit` | gated |
| `block-raw-gh-pr-create` | gated |
| `block-protected-branch-work` | gated |
| `block-associative-arrays` | gated |
| `remind-finalize` | gated |
| `detect-deprecation-warnings` | gated |
| `stop-guard-finalization` | gated (uses `$PWD` since Stop hooks lack `.cwd`) |
| `block-heredoc` | **NOT gated** — heredocs always misbehave, rule is universal |

Per the design discussion on the issue: gating `block-protected-branch-work` means the "block commits to develop/main" fallback no longer fires in unmanaged repos. That's intentional — agents and humans doing ad-hoc work in unmanaged repos should follow that repo's own conventions, not have one imposed by this plugin.

## Smoke tests

Verified manually with the helper sourced in a subshell:

- Inside this repo (has `docs/repository-standards.md`): `is_managed_repo` returns 0 ✓
- In `/tmp` (no git, no markers): returns 1 ✓
- In a fresh `git init` directory with no markers: returns 1 ✓ (terminates at `.git` sentinel)

## Files

- `hooks/scripts/lib/managed-repo-check.sh` — new shared helper
- 7 hook scripts updated to source the helper and gate
- `docs/site/docs/hooks/index.md` — new "Managed-repo gating" section
- `README.md` — hook table preface notes the gate

## Out of scope

The full `st-config.yaml` design is deferred. Today's check is just "does either file exist?" — content is irrelevant. When `st-config.yaml` becomes the canonical config, support for the existing `docs/repository-standards.md` marker can be dropped in a follow-up.