### PR TITLE
chore(ci): migrate standard-actions refs from @develop to @v1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@develop
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.3
     with:
       language: bash
       semgrep-language: ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,6 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@develop
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.3
         with:
           version-command: jq -r '.version | split(".") | .[0:2] | join(".")' .claude-plugin/plugin.json


### PR DESCRIPTION
# Pull Request

## Summary

- Migrate standard-actions refs from @develop to @v1.3

## Issue Linkage

- Closes #109

## Testing

- markdownlint

## Notes

- Pins ci-security.yml and docs-deploy to @v1.3 rolling minor tag. Existing @v1.1/@v1.2 pins (publish/tag-and-release, publish/version-bump-pr, release-gates/version-divergence) are intentionally left as-is per migration plan in standard-actions#145.