### PR TITLE
docs(skills): publish + pr-workflow: docs.yml verification, Phase 6 closure, Phase 7 hand-off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,3 +178,19 @@ after a new release, the canonical sequence is in the README's
 the sequence is three steps (`marketplace update` → `update` →
 `reload-plugins`) and each is required. The non-interactive CLI
 form is `claude plugin update <plugin>@<marketplace>`.
+
+## Development and deployment of this repo
+
+Working on the plugin itself (vs. consuming it) has its own
+canonical procedure. See
+[`README.md` → Development and deployment](README.md#development-and-deployment)
+for: worktree setup, the `pr-workflow` skill for shipping a
+change, the `publish` skill for cutting a release, and the
+**post-publish Phase 7 hand-off** which is the producer-side
+obligation to surface the consumer-refresh sequence to the user
+at release time.
+
+When you complete a publish, **the cycle is not done until you
+have shown the user the three-step refresh sequence.** Listing
+artifacts and stopping is a regression on
+[#105](https://github.com/wphillipmoore/standard-tooling-plugin/issues/105).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ in every Claude Code session.
 - [Component inventory](#component-inventory)
 - [Plugin namespace](#plugin-namespace)
 - [Related repositories](#related-repositories)
-- [Development](#development)
+- [Development and deployment](#development-and-deployment)
 
 ## What this plugin does
 
@@ -191,18 +191,96 @@ Example: `/standard-tooling:pr-workflow`.
 - [`standard-actions`](https://github.com/wphillipmoore/standard-actions)
   — Shared GitHub Actions composite actions consumed by CI.
 
-## Development
+## Development and deployment
 
-Contributors working on the plugin itself can load it directly from
-the source tree to avoid the marketplace round-trip:
+This section covers contributing to the plugin itself — how to set
+up a working environment, ship a change, and complete the
+post-publish hand-off. Distinct from the [Install](#install) and
+[Update](#update) sections, which cover how a *consumer* of the
+plugin uses it. The two roles have different obligations.
+
+### Set up a worktree
+
+Sessions on this repo always start at the project root
+(`~/dev/github/standard-tooling-plugin/`), never inside a
+worktree. Each in-flight issue gets its own worktree under
+`.worktrees/issue-<N>-<slug>/` on a `feature/<N>-<slug>` branch.
+The full procedure (issue resolution, sub-issue creation,
+worktree+branch creation, agent prompt template) lives at
+[`docs/development/starting-work-on-an-issue.md`](docs/development/starting-work-on-an-issue.md).
+
+The worktree convention is enforced by the
+`block-protected-branch-work` hook: commits originating from
+outside `.worktrees/*/` are denied.
+
+### Ship a change
+
+Use the [`pr-workflow` skill](skills/pr-workflow/SKILL.md) to
+submit, wait for CI green, and hand off:
+
+```text
+/standard-tooling:pr-workflow
+```
+
+The agent submits via `st-submit-pr`, waits for CI to go green,
+fixes agent-fixable failures, and hands off to you for review and
+merge. Auto-merge is disabled fleet-wide; you review and merge
+feature/bugfix PRs manually. After you report the merge, the
+agent runs `st-finalize-repo` from inside the worktree.
+
+### Cut a release
+
+Use the [`publish` skill](skills/publish/SKILL.md):
+
+```text
+/standard-tooling:publish
+```
+
+The skill drives Phases 1–7: prepare release, merge release PR
+via `st-merge-when-green` (the documented exception to the
+"humans review human PRs" policy — release PRs are
+agent-authored and agent-merged), merge the post-publish bump
+PR, confirm both `publish.yml` and `docs.yml` succeeded on
+`main`, optionally do dependency updates, close the tracking
+issue with a summary, finalize, and surface the consumer-refresh
+sequence.
+
+### Post-publish hand-off (Phase 7)
+
+**A release is not concluded until consumers have refreshed.**
+After `publish.yml` and `docs.yml` succeed, every Claude Code
+session that has this plugin installed needs to run:
+
+```text
+/plugin marketplace update standard-tooling-marketplace
+/plugin update standard-tooling@standard-tooling-marketplace
+/reload-plugins
+```
+
+The agent producing the release surfaces this sequence in its
+hand-off message. The user runs it (in this session, or in any
+new session that wants the new plugin behavior). Without the
+refresh, hooks and skills stay on the previously-cached version
+and the release is invisible to running sessions.
+
+This is the user-facing
+[Update](#update) sequence, surfaced from the producer side at
+the moment of release rather than left to the user to remember.
+
+### Develop against the source tree
+
+When iterating on hooks or skills before release, load the plugin
+directly from the source tree to avoid the marketplace
+round-trip:
 
 ```bash
 claude --plugin-dir /path/to/standard-tooling-plugin
 ```
 
-This bypasses `~/.claude/plugins/cache/` and mounts the working tree
-as the plugin source. Useful for iterating on hooks and skills before
-release.
+This bypasses `~/.claude/plugins/cache/` and mounts the working
+tree as the plugin source.
 
-Reporting issues or requesting changes: open an issue at
+### Reporting issues
+
+Open an issue at
 <https://github.com/wphillipmoore/standard-tooling-plugin/issues>.

--- a/docs/development/skills-architecture.md
+++ b/docs/development/skills-architecture.md
@@ -206,9 +206,16 @@ that section is current. Outstanding issues:
 and v1.4.4 releases this session ran cleanly under it). Three
 gaps above are tracked patches, not blocking.
 
-**Status: PATCHES.**
+**Status (audit): PATCHES.**
 
-**Folds in:**
+**Status (post-audit): COMPLETE.** All three patches landed in
+the step-3 PR. Phase 4 now blocks on both `publish.yml` and
+`docs.yml`; Phase 6 closes the tracking issue with summary
+before `st-finalize-repo`; new Phase 7 surfaces the
+consumer-refresh sequence explicitly. `pr-workflow` got a
+matching post-merge docs-deploy verification step.
+
+**Resolved:**
 [#83](https://github.com/wphillipmoore/standard-tooling-plugin/issues/83),
 [#84](https://github.com/wphillipmoore/standard-tooling-plugin/issues/84),
 [#105](https://github.com/wphillipmoore/standard-tooling-plugin/issues/105).
@@ -413,17 +420,38 @@ explicit "humans review and merge feature/bugfix PRs" policy,
 CI-green-wait per #85, worktree-aware finalization, pointer to
 `starting-work-on-an-issue.md` from the preflight.
 
-### 3. `publish` skill patches (closes #83, #84, #105)
+### 3. `publish` skill patches (closes #83, #84, #105) — DONE
 
-Smaller scope; can run in parallel with #1 / #2 since publish is at
-the C-phase.
+**Status update (post-audit, 2026-04-28): completed.**
 
-Scope:
+- Phase 4 now blocks on **both** `publish.yml` and `docs.yml`
+  workflow completions (#84). Half-shipped releases with broken
+  docs no longer slip through.
+- Phase 6 prose tightened: the release cycle is **not complete**
+  until the tracking issue is closed with a full summary
+  comment. Step order changed so the tracking issue closes
+  *before* `st-finalize-repo` (the historical record gets
+  sealed even if finalize errors on a sibling worktree). #83.
+- New **Phase 7** added: producer-side consumer-refresh hand-off
+  (#105). The agent is responsible for surfacing the
+  three-step refresh sequence to the user as part of the
+  release boundary, not stopping after Phase 6 with an artifact
+  list.
+- `pr-workflow` got a parallel post-merge docs-deploy
+  verification step for the dev site (#84's pr-workflow
+  acceptance).
+- `README.md` got a new **Development and deployment** section
+  that distinguishes contributor obligations from consumer
+  obligations and surfaces Phase 7 explicitly. `CLAUDE.md`
+  references it.
 
-- Phase 6 auto-close tracking issue with summary template.
-- Phase 4 sanity-check `docs.yml` alongside `publish.yml`.
-- New post-Phase-6 hand-off: tell the user to run the
-  three-step refresh.
+**Out of scope (deferred follow-ups):** the cross-repo
+`docs.yml`-trigger audit document mentioned in #84's
+acceptance, and the cross-ecosystem follow-up issues (per-repo
+deploy docs for `standard-tooling`,
+`standard-tooling-docker`, `standard-actions`) mentioned in
+#105's acceptance. Both are bigger than the audit's step 3
+scope and tracked separately.
 
 ### 4. `summarize` decision (closes #58)
 

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -188,6 +188,27 @@ verify the develop pull and merged-branch deletion succeeded
 manually with `git log --oneline -3` and `git worktree list`. Do
 not force-remove sibling worktrees.
 
+### Verify docs deploy
+
+If the repo has a `docs.yml` workflow (or equivalent) that
+deploys the dev docs site on push to `develop`, verify it
+succeeded for the merge commit. The run is asynchronous; it
+typically completes within 30–60 seconds of the merge.
+
+```bash
+gh run list --workflow docs.yml --branch develop --limit 1 \
+  --json conclusion,status,url --jq '.[0]'
+```
+
+- If `status == "completed" && conclusion == "success"`: pass.
+- If still in progress: wait briefly (`gh run watch --exit-status <run-id>`).
+- If failed: surface to the user. A failed docs deploy after a
+  merged PR means the dev docs site is stale; this is the same
+  silent-failure class as a release with broken docs.
+
+If the repo has no `docs.yml` (or the merged PR didn't touch
+docs), skip this step.
+
 This concludes the work cycle.
 
 ## Resources

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -18,7 +18,8 @@ description: Drive the end-to-end publish workflow for library, tooling, and doc
   - [Phase 3 — Merge bump PR](#phase-3--merge-bump-pr)
   - [Phase 4 — Confirm publish](#phase-4--confirm-publish)
   - [Phase 5 — Next-cycle dependency updates](#phase-5--next-cycle-dependency-updates)
-  - [Phase 6 — Close and finalize](#phase-6--close-and-finalize)
+  - [Phase 6 — Close tracking issue and finalize](#phase-6--close-tracking-issue-and-finalize)
+  - [Phase 7 — Consumer-refresh hand-off](#phase-7--consumer-refresh-hand-off)
 - [Docs-only mode](#docs-only-mode)
   - [Phase 1 — Confirm deployment](#phase-1--confirm-deployment)
   - [Phase 2 — Toolchain dependency updates](#phase-2--toolchain-dependency-updates)
@@ -270,22 +271,50 @@ behind external async work.
 
 ### Phase 4 — Confirm publish
 
-Block until the `publish.yml` workflow on `main` completes
-successfully, then verify all publish artifacts:
+Block until **both** asynchronous workflows triggered by the
+release-PR merge complete successfully:
 
-- Workflow run conclusion is `success`.
+1. `publish.yml` on `main` — tag, GitHub Release, package artifact
+   to the registry.
+2. `docs.yml` (or the repo's documentation deploy workflow) on
+   `main` — versioned docs site deploy.
+
+`docs.yml` is a separate async workflow from `publish.yml`. A
+release that tagged and published the package but whose docs
+failed to deploy is a half-shipped release that looks identical
+to a working one until a user tries to read the docs. Do not
+declare Phase 4 complete until both workflows succeed.
+
+Block on each workflow:
+
+```bash
+gh run watch --exit-status \
+  $(gh run list --workflow publish.yml --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
+
+gh run watch --exit-status \
+  $(gh run list --workflow docs.yml --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
+```
+
+Adjust the docs workflow filename if the repo uses a different
+name (e.g., `pages.yml`, `mkdocs.yml`).
+
+Then verify all publish artifacts:
+
+- Both workflow run conclusions are `success`.
 - Git tag `v<version>` on `main`.
 - Develop tag `develop-v<version>` for changelog boundaries.
 - GitHub Release created.
 - Package artifact published to the registry.
-- GitHub Pages documentation deployed for the new version.
+- GitHub Pages documentation deployed for the new version
+  (e.g., `mike list` shows the new version, or the docs site
+  serves the new version under its versioned URL).
 
-If `publish.yml` failed, follow the failure-handling procedure.
-A failed publish after successful PR merges leaves the repository
-half-released; surface the failure and stop.
+If either workflow failed, follow the failure-handling
+procedure. A failed publish after successful PR merges leaves
+the repository half-released; surface the failure and stop.
 
-Comment on the tracking issue with Phase 4 results (publish-run
-URL, list of artifacts confirmed).
+Comment on the tracking issue with Phase 4 results (both run
+URLs, list of artifacts confirmed).
 
 ### Phase 5 — Next-cycle dependency updates
 
@@ -297,14 +326,74 @@ URL, list of artifacts confirmed).
 5. Comment on the tracking issue with Phase 5 results (dependency update PR
    URL, categories updated).
 
-### Phase 6 — Close and finalize
+### Phase 6 — Close tracking issue and finalize
 
-1. Close the tracking issue with a final summary comment covering all phases.
-   All issue and PR references in the summary must be full URLs (not short
-   `#N` references) so they are clickable in the terminal.
-2. Run `st-finalize-repo` to return to a clean `develop`
-   branch. The script updates local `develop`, deletes merged branches, and
-   prunes stale remotes. Run final validation to confirm a clean state.
+**The release cycle is not complete until the tracking issue is
+closed with a summary comment.** Same posture as Phase 4: the
+repo's historical record is a release artifact, and an open
+tracking issue is an unfinished release as far as future readers
+can tell. Skipping this step is a failure to complete, not a
+nice-to-have.
+
+Order matters here. Close the tracking issue **before**
+`st-finalize-repo` so the historical record is sealed first; if
+finalize errors out (e.g., a sibling worktree blocks cleanup),
+the bookkeeping is still done.
+
+1. **Close the tracking issue with a final summary comment.**
+   Required content in the summary:
+
+   - All PR URLs (release PR, bump PR, any recovery PRs)
+   - Tag, develop tag, GitHub Release URLs
+   - `publish.yml` and `docs.yml` (or equivalent) run URLs from
+     Phase 4
+   - Any failures encountered and the resolutions
+
+   All issue and PR references in the summary must be full URLs
+   (not short `#N` references) so they are clickable in the
+   terminal.
+
+2. **Run `st-finalize-repo`** to return to a clean `develop`
+   branch. The script updates local `develop`, deletes merged
+   branches, and prunes stale remotes. Run final validation to
+   confirm a clean state.
+
+3. **Continue to Phase 7.** Phase 6 alone does not conclude the
+   cycle; the producer-side hand-off in Phase 7 is the actual
+   release boundary for consumers.
+
+### Phase 7 — Consumer-refresh hand-off
+
+The release artifacts are published, but **consumers haven't
+picked them up yet.** Every Claude Code session that has this
+plugin (or any standard-tooling-distributed plugin) installed
+needs an explicit local refresh — neither `docker run` nor
+`/plugin marketplace update` auto-pulls fresh content. The agent
+producing the release is responsible for surfacing the refresh
+step explicitly to the user. Listing artifacts and stopping is
+not the end of the cycle; saying "v\<version> shipped, now run
+the refresh sequence" is.
+
+Surface the consumer-side update sequence verbatim. For this
+repo (`standard-tooling-plugin`):
+
+```text
+/plugin marketplace update standard-tooling-marketplace
+/plugin update standard-tooling@standard-tooling-marketplace
+/reload-plugins
+```
+
+For other tool-providing repos (`standard-tooling`,
+`standard-tooling-docker`, `standard-actions`), use the
+repo-specific refresh sequence — see each repo's `Development
+and deployment` section in its README. If the repo doesn't
+document a refresh sequence, that's a gap to file separately;
+do not invent one.
+
+Phase 7 ends when the user has seen the refresh sequence in the
+hand-off message. The user is not required to *run* the
+sequence in this session; they are required to *see* it as
+part of the producer's hand-off.
 
 ## Docs-only mode
 


### PR DESCRIPTION
# Pull Request

## Summary

- publish + pr-workflow: docs.yml verification, Phase 6 closure, Phase 7 hand-off

## Issue Linkage

- Resolves #83

## Testing

- markdownlint

## Notes

- Step 3 of the skills audit attack order (#114). Three patches across publish + pr-workflow + repo docs that close #83, #84, and #105 in one focused PR.

## What changed

### `skills/publish/SKILL.md`

- **Phase 4 (#84)**: now blocks on **both** `publish.yml` and `docs.yml` asynchronous workflows on `main`. A release that tagged and published the package but whose docs failed to deploy is a half-shipped release that looks identical to a working one until a user tries to read the docs. Both `gh run watch --exit-status` invocations documented; failure handling unchanged.
- **Phase 6 (#83)**: tightened prose. The release cycle is now explicitly **not complete** until the tracking issue is closed with a full summary comment. Step order changed: tracking issue closes **before** `st-finalize-repo` so the historical record is sealed even if finalize errors on a sibling worktree. Required summary content enumerated.
- **New Phase 7 (#105)**: consumer-refresh hand-off. The agent is responsible for surfacing the three-step refresh sequence (`/plugin marketplace update` → `/plugin update` → `/reload-plugins`) explicitly to the user as part of the release boundary. Listing artifacts and stopping is no longer the end of the cycle. Repo-specific refresh sequences for non-plugin repos noted.

### `skills/pr-workflow/SKILL.md`

- Parallel post-merge **docs-deploy verification** step for the dev site (#84's `pr-workflow` acceptance). After `st-finalize-repo`, verify the `docs.yml` run on `develop` succeeded for the merge commit. Skip if the repo has no `docs.yml` or the merged PR didn't touch docs.

### `README.md`

- New **Development and deployment** section. Covers worktree setup (links to `docs/development/starting-work-on-an-issue.md`), `pr-workflow` for shipping a change, `publish` for cutting a release, **the Phase 7 hand-off explicitly**, and the existing source-tree dev pattern.
- TOC updated.

### `CLAUDE.md`

- New **Development and deployment of this repo** section that points at the README and emphasizes Phase 7's non-skippable nature for the agent.

### `docs/development/skills-architecture.md`

- Part 2 `publish` entry status flipped to **COMPLETE**.
- Part 4 attack-order step 3 marked **DONE** with notes on what landed and what's deferred.

## Retroactive housekeeping

Per #83, the 5 orphaned tracking issues (`standard-actions#189`, `#194`, `#199`, `standard-tooling-plugin#66`, `#71`) had Phase-6-style summary comments added retroactively. They were all already closed without summaries; the comments seal the historical record per the new Phase 6.

## Out of scope (deferred)

- The **cross-repo `docs.yml`-trigger audit document** mentioned in #84's acceptance — bigger than step 3 and tracked separately.
- **Cross-ecosystem follow-up issues** (per-repo deploy docs for `standard-tooling`, `standard-tooling-docker`, `standard-actions`) mentioned in #105's acceptance — separate per-repo issues to file once this lands the plugin-side template.
- A **`st-wait-for-green` CLI** mentioned in #85's notes — not needed; the existing `gh run watch --exit-status` and `gh pr checks --watch` patterns are sufficient for now.

## Why this is a step 3 PR

Per the audit's #114 attack order, step 3 was scoped as: Phase 4 `docs.yml` check, Phase 6 close-tracker enforcement, post-Phase-6 reload-plugins hand-off. All three landed here, plus the matching `pr-workflow` post-merge verification. The next step (4) is `summarize` decision per #58.