### PR TITLE
docs(skills): summarize: keep three-mode unified skill; SOC mode is canonical for the fleet

### DIFF
--- a/docs/development/skills-architecture.md
+++ b/docs/development/skills-architecture.md
@@ -298,18 +298,27 @@ and operations modes may be unused.
 use case). Decisions and operations modes are functional but
 unused.
 
-**Status: INVESTIGATE + DECIDE.** The candidate outcomes in #58:
+**Status (audit): INVESTIGATE + DECIDE.**
 
-- **A.** Keep all three modes; retire project-local `soc-capture`.
-- **B.** Split SOC out into a dedicated skill.
-- **C.** Trim — delete unused modes.
-- **D.** Project-local `soc-capture` stays canonical; this skill
-  serves a different purpose.
+**Status (post-audit): COMPLETE.** Decision **A** (keep all three
+modes; SOC stays unified with the rest of the skill). The
+investigation surfaced a small surprise: there is no `soc-capture`
+or `summarize-soc` skill anywhere in the fleet — the names are
+dangling references in `the-infrastructure-mindset`'s `CLAUDE.md`,
+`AGENTS.md`, and `skills/article-workflow/SKILL.md`. The
+mechanism that has been doing SOC capture all along is this
+skill's SOC mode.
 
-This is a small skill; the investigation belongs to its own
-focused PR.
+Plugin-side change: added a "Canonical SOC capture for the fleet"
+section to the SOC mode that explicitly names the dangling
+references and links to #58 for the rationale.
 
-**Folds in:**
+Cross-repo follow-up filed as
+[the-infrastructure-mindset#165](https://github.com/wphillipmoore/the-infrastructure-mindset/issues/165)
+to fix the stale references in that repo. Out of scope for this
+plugin PR.
+
+**Resolved:**
 [#58](https://github.com/wphillipmoore/standard-tooling-plugin/issues/58).
 
 ## Part 3 — Coverage gaps
@@ -453,10 +462,25 @@ deploy docs for `standard-tooling`,
 #105's acceptance. Both are bigger than the audit's step 3
 scope and tracked separately.
 
-### 4. `summarize` decision (closes #58)
+### 4. `summarize` decision (closes #58) — DONE
 
-Small. Investigate + pick one of the four candidate outcomes;
-implement.
+**Status update (post-audit, 2026-04-28): completed.** Decision
+**A** — keep `summarize` with all three modes; SOC mode is the
+canonical SOC capture mechanism for the fleet. The investigation
+surfaced that there is no `soc-capture` or `summarize-soc` skill
+anywhere; both names are dangling references in
+`the-infrastructure-mindset`. This skill's SOC mode is what's
+been doing the work all along.
+
+Plugin-side: added a "Canonical SOC capture for the fleet"
+section to `summarize`'s SOC mode that names the dangling
+references explicitly so future agents don't get confused.
+
+Cross-repo: filed
+[`the-infrastructure-mindset#165`](https://github.com/wphillipmoore/the-infrastructure-mindset/issues/165)
+to fix the stale references in that repo (CLAUDE.md, AGENTS.md,
+skills/article-workflow/SKILL.md). That work happens in a
+separate agent session per the user's instruction.
 
 ### 5. `project-issue` framing patch
 

--- a/docs/site/docs/skills/index.md
+++ b/docs/site/docs/skills/index.md
@@ -19,7 +19,7 @@ substantially change it.
 | [project-issue](#project-issue) | Create a well-structured GitHub issue via guided questions | Current |
 | [dependency-update](#dependency-update) | Run the dependency-update workflow | Current (reviewed 2026-04-23, no changes) |
 | [deprecation-triage](#deprecation-triage) | Triage deprecation warnings into tracking issues | Current (reviewed 2026-04-23, no changes) |
-| [summarize](#summarize) | Decision / operation / stream-of-consciousness summaries | Current; relationship with `soc-capture` to be clarified in [#58](https://github.com/wphillipmoore/standard-tooling-plugin/issues/58) |
+| [summarize](#summarize) | Decision / operation / stream-of-consciousness summaries; SOC mode is the canonical capture for the fleet | Current |
 
 ## pr-workflow
 
@@ -129,12 +129,16 @@ three modes:
 summary, invokes SOC capture, or the skill is invoked via
 handoff protocols.
 
-**Status.** Current, with an open clarification: earlier session
-notes referred to a separate `soc-capture` concept as if it were
-distinct from the `soc` mode inside `summarize`. Whether those
-are actually the same thing — or whether `soc` should become its
-own top-level skill — is tracked in
-[plugin#58](https://github.com/wphillipmoore/standard-tooling-plugin/issues/58).
+**Status.** Current. Decision A from
+[plugin#58](https://github.com/wphillipmoore/standard-tooling-plugin/issues/58):
+this skill's SOC mode is the canonical SOC capture mechanism for
+the fleet. Repo-local references to `soc-capture` or
+`summarize-soc` as skill names are stale pointers — splitting
+SOC into its own skill was rejected because capture and summary
+are intertwined here (`End SOC` triggers the structured summary).
+The cross-repo references in `the-infrastructure-mindset` are
+tracked for cleanup in
+[the-infrastructure-mindset#165](https://github.com/wphillipmoore/the-infrastructure-mindset/issues/165).
 
 ## How skills work — technical
 

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -71,6 +71,18 @@ Follow the Summarize Stream of Consciousness Protocol.
 - `End SOC` ends capture mode and triggers the structured summary.
 - If SOC is not closed with `End SOC`, do not produce a summary.
 
+### Canonical SOC capture for the fleet
+
+This SOC mode is the canonical SOC capture mechanism for every
+repo in the fleet that uses voice→text→article workflows
+(notably `the-infrastructure-mindset`). Repo-local references
+to `soc-capture` or `summarize-soc` as skill names are stale
+pointers — the real skill is this one, in SOC mode. See
+[`#58`](https://github.com/wphillipmoore/standard-tooling-plugin/issues/58)
+for the rationale: capture and summary are intertwined here
+(`End SOC` triggers the structured summary), so splitting SOC
+into its own skill adds no semantic gain.
+
 ## Output templates
 
 Decisions:


### PR DESCRIPTION
# Pull Request

## Summary

- summarize: keep three-mode unified skill; SOC mode is canonical for the fleet

## Issue Linkage

- Resolves #58

## Testing

- markdownlint

## Notes

- Step 4 of the skills audit attack order (#114). Closes #58 with **decision A**: keep `summarize` with all three modes; SOC mode is the canonical SOC capture mechanism for the fleet.

## Investigation finding

There is no `soc-capture` or `summarize-soc` skill anywhere in the fleet. Both names appear in `the-infrastructure-mindset`'s `CLAUDE.md`, `AGENTS.md`, and `skills/article-workflow/SKILL.md`, but neither maps to a real, invocable skill. The mechanism that has been doing SOC capture all along is **this skill's SOC mode**.

## Why decision A

| Option | Verdict | Reason |
|---|---|---|
| **A. Keep all three modes** | ✅ Selected | Mechanism already works as one skill; capture and summary are intertwined in SOC (`End SOC` triggers the summary); decisions/operations have no good home elsewhere. |
| B. Split SOC into its own skill | ❌ | No semantic gain; `End SOC` triggering structured summary is the load-bearing pattern. |
| C. Trim decisions/operations modes | ❌ | Cost-to-keep is near zero; they're occasionally useful (the audit's framing this session implicitly used decisions-mode style). |
| D. Project-local soc-capture is canonical | ❌ | There is no project-local soc-capture; the references are dangling. |

## What changed

- **`skills/summarize/SKILL.md`** — added a 'Canonical SOC capture for the fleet' section to the SOC mode that explicitly names the dangling references (`soc-capture`, `summarize-soc`) and links to #58 for the rationale. Future agents reading repos with stale pointers know to ignore the names and use this skill.
- **`docs/development/skills-architecture.md`** — Part 2 entry status flipped to **COMPLETE**; Part 4 attack-order step 4 marked **DONE**.
- **`docs/site/docs/skills/index.md`** — table row and detail section updated to reflect decision A.

## Cross-repo follow-up

Filed [`the-infrastructure-mindset#165`](https://github.com/wphillipmoore/the-infrastructure-mindset/issues/165) to fix the dangling references in that repo (3 files, 4 references). Per the user's instruction, that work happens in a separate agent session — this PR is plugin-side only.

## Attack order impact

Steps 5 (`project-issue` framing patch), 6 (`deprecation-triage` polish), and 7 (`dependency-update` rewrite/expansion) remain. The user has noted the project-issue scope has expanded beyond a framing patch given recent project-board usage patterns; that conversation reopens at step 5.

## No version bump

Develop is already at 1.4.5 from the v1.4.4 release; this PR rides that.