### PR TITLE
docs(skills): complete audit steps 6-7, align host/container routing (#96)

### DIFF
--- a/docs/development/skills-architecture.md
+++ b/docs/development/skills-architecture.md
@@ -235,10 +235,17 @@ session — it doesn't say *how* to update Python deps vs. CI action
 versions vs. doc-toolchain pins. Each category needs its own
 concrete commands.
 
-**Status: REWRITE / EXPANSION.** The skill needs to actually
-encode what to run for each dependency category named in the
-`publish` skill's Phase 5 ("Dependency update categories"). Right
-now it documents a process by reference; it should drive it.
+**Status (audit): REWRITE / EXPANSION.**
+
+**Status (post-audit): COMPLETE.** Full rewrite. The skill now
+encodes concrete commands per dependency category (library deps
+via `uv lock --upgrade`, CI action pins, runtime versions, doc
+toolchain, linters, test frameworks, build tools). Validation
+uses `st-validate-local`. Failure handling structured around the
+anchored dependency record workflow. Anchor review is a
+first-class section: every sweep checks existing anchors for
+exit-criteria resolution. Submission hands off explicitly to
+`pr-workflow`.
 
 **Folds in:** none currently filed; the audit surfaces this.
 
@@ -256,9 +263,12 @@ explicit pointer in either direction. Otherwise unchanged.
 **Slash-command runnability.** Yes for the core triage flow when
 invoked with a warning in hand.
 
-**Status: MINOR POLISH.** Make the hook→skill seam explicit (a
-sentence in the skill's "When to use," and a corresponding
-mention in the hook's docstring or hooks reference doc).
+**Status (audit): MINOR POLISH.**
+
+**Status (post-audit): COMPLETE.** Added a "When to use" section
+naming the `detect-deprecation-warnings` PostToolUse hook as the
+primary trigger, with a note that the skill can also be invoked
+directly for warnings outside the hook's scope.
 
 **Folds in:** none currently filed.
 
@@ -397,7 +407,7 @@ issue.
 Recommended sequence. Each step is a focused PR closing one or
 more existing issues and referencing #114.
 
-### 1. ~~`branch-workflow` rewrite~~ → eliminate `branch-workflow`, extract to doc (closes #55) — DONE
+### 1. Eliminate `branch-workflow`, extract to doc (closes #55) — DONE
 
 **Status update (post-audit, 2026-04-27): completed.** After
 discussion the user pushed back on whether `branch-workflow`
@@ -459,7 +469,7 @@ CI-green-wait per #85, worktree-aware finalization, pointer to
 acceptance, and the cross-ecosystem follow-up issues (per-repo
 deploy docs for `standard-tooling`,
 `standard-tooling-docker`, `standard-actions`) mentioned in
-#105's acceptance. Both are bigger than the audit's step 3
+issue 105's acceptance. Both are bigger than the audit's step 3
 scope and tracked separately.
 
 ### 4. `summarize` decision (closes #58) — DONE
@@ -482,25 +492,36 @@ to fix the stale references in that repo (CLAUDE.md, AGENTS.md,
 skills/article-workflow/SKILL.md). That work happens in a
 separate agent session per the user's instruction.
 
-### 5. `project-issue` framing patch
+### 5. `project-issue` scope discussion — DEFERRED
 
-Small. Fix the host/container intro section.
+**Status update (post-audit, 2026-04-28):** Per user feedback after
+merging #115, the scope expanded beyond a framing patch. GitHub
+Projects integration hasn't been load-bearing in recent fleet
+usage, raising questions about whether `project-issue` should
+default to "file in this repo, no project" when no project is
+configured. See the note on #114 for the full discussion scope.
+Deferred to a separate issue.
 
-### 6. `deprecation-triage` polish
+### 6. `deprecation-triage` polish — DONE
 
-Small. Make the hook→skill seam explicit.
+**Status update (post-audit, 2026-04-28): completed.** Added a
+"When to use" section that explicitly names the
+`detect-deprecation-warnings` PostToolUse hook as the primary
+trigger and describes the hook→skill seam. The hook already
+referenced the skill; now the skill references the hook.
 
-### 7. `dependency-update` rewrite/expansion
+### 7. `dependency-update` rewrite/expansion — DONE
 
-Last among the existing skills. Needs the work-cycle skills to be
-canonical first, so the "submit via PR" hand-off is clean.
-
-Scope:
-
-- Encode concrete commands per dependency category (Python deps,
-  CI action pins, doc toolchain, linters, runtime versions).
-- Reference `st-validate-local` as the canonical validation step.
-- Tighten the failure-handling around anchored records.
+**Status update (post-audit, 2026-04-28): completed.** Full
+rewrite. The skill now encodes concrete commands per dependency
+category (Python direct deps and lockfile via `uv lock`, CI
+action pins, runtime version pins, doc toolchain, linters, test
+frameworks, build tools). Validation uses `st-validate-local` as
+the canonical step. Failure handling is structured around the
+anchored dependency record workflow with explicit "never silently
+pin" policy. Submission hands off to `pr-workflow`. Added anchor
+review as a first-class section — every sweep must check existing
+anchors for exit-criteria resolution.
 
 ### 8. New-skill TODOs (filed during the work, not implemented in this PR)
 

--- a/skills/dependency-update/SKILL.md
+++ b/skills/dependency-update/SKILL.md
@@ -8,48 +8,201 @@ description: Run the dependency update workflow with validation, failure handlin
 ## Table of Contents
 
 - [Overview](#overview)
+- [When to use](#when-to-use)
+- [Host vs container commands](#host-vs-container-commands)
 - [Preflight](#preflight)
-- [Workflow](#workflow)
+- [Library dependencies](#library-dependencies)
+- [Toolchain dependencies](#toolchain-dependencies)
+- [Anchor review](#anchor-review)
+- [Validation](#validation)
 - [Failure handling](#failure-handling)
-- [Completion](#completion)
+- [Submission](#submission)
 - [Resources](#resources)
 
 ## Overview
 
 Execute a repeatable dependency update process that prioritizes stability and
-traceability. Use language-specific standards when present.
+traceability. Each category follows the same pattern: update at the source of
+truth, regenerate derived artifacts, run full validation. When a dependency
+cannot be updated, the failure is recorded as an anchored dependency record
+with exit criteria — never silently pinned.
+
+## When to use
+
+- **Post-publish (Phase 5):** The `publish` skill's Phase 5 hands off to this
+  skill after a release ships. Develop is the safest place to absorb updates
+  because it has the widest validation window before the next release.
+- **Standalone:** Invoked directly via `/standard-tooling:dependency-update`
+  when a dependency update is needed outside a release cycle (security alert,
+  deprecation, planned upgrade).
+
+## Host vs container commands
+
+Most commands in this skill are **host commands** — invoke them directly
+without `st-docker-run` wrapping. This includes `uv`, `gh`, `st-commit`,
+`st-validate-local`, and all `st-*` workflow tools.
+
+The only container-dispatched work happens inside `st-validate-local`,
+which handles that routing internally. See the
+[`publish` skill's host-vs-container section](../publish/SKILL.md#host-vs-container-commands)
+for the canonical split and rationale
+([#96](https://github.com/wphillipmoore/standard-tooling-plugin/issues/96)).
 
 ## Preflight
 
-- Identify the relevant dependency standards for the repository.
-- Confirm sources of truth for dependency versions and lockfiles.
-- If the repository defines a canonical validation command, capture it.
+1. Confirm you are on a `chore/` branch off `develop` (e.g.,
+   `chore/next-cycle-deps-<version>` for post-publish, or
+   `chore/dep-update-<date>` for standalone).
+2. Read `docs/repository-standards.md` to identify:
+   - `repository_type` — determines which categories apply.
+   - The canonical validation command.
+3. Verify `GH_TOKEN` is set.
+4. Locate `st-docker-run` using the standard search algorithm (see the
+   `publish` skill's preflight for the lookup order) — needed only for
+   validation steps that dispatch into the container.
 
-## Workflow
+## Library dependencies
 
-1. Collect update signals (security alerts, audits, planned upgrades).
-2. Update dependencies at their sources of truth.
-3. Regenerate derived artifacts (lockfiles, exports, or generated manifests).
-4. Run the full validation and test suite.
-5. Proceed through the standard pull request workflow.
+Applies to repos where `repository_type` is `library` or `tooling`.
+
+### Direct dependencies
+
+1. Read `pyproject.toml` — the `[project.dependencies]` and
+   `[project.optional-dependencies]` tables are the sources of truth.
+2. Run `uv lock --upgrade` to regenerate `uv.lock` with the latest
+   compatible versions.
+3. If a dependency has an upper bound (`<X.Y`), check whether the bound is
+   still necessary. If the upstream release that caused the bound has been
+   fixed, remove the bound and re-lock.
+
+### Lockfile regeneration
+
+After any change to `pyproject.toml` or after `uv lock --upgrade`:
+
+```bash
+uv lock
+```
+
+Verify the lockfile is consistent:
+
+```bash
+uv lock --check
+```
+
+## Toolchain dependencies
+
+Applies to all managed repos.
+
+### CI action version pins
+
+1. Scan `.github/workflows/*.yml` for `uses:` directives.
+2. For each pinned action (`owner/action@vN.M` or `owner/action@sha`), check
+   the action's releases for newer versions.
+3. Update pins in-place. Prefer tag pins (`@vN`) over SHA pins unless the
+   action's documentation recommends otherwise.
+
+### Runtime version pins
+
+1. Read the runtime version support policy tier model from the repository
+   profile.
+2. Check whether any supported runtime versions have been end-of-lifed or
+   whether new versions should be added to the test matrix.
+3. Update `.github/workflows/*.yml` matrix entries and any runtime version
+   pins in `pyproject.toml` (`requires-python`).
+
+### Documentation toolchain
+
+Update in `pyproject.toml` under the `[project.optional-dependencies]` docs
+group (or equivalent):
+
+- `mkdocs-material`
+- `mike`
+- `mkdocstrings` and language handlers
+
+### Linters, formatters, and type checkers
+
+Update in `pyproject.toml` under the dev dependency group:
+
+- `ruff`
+- `mypy` / `ty`
+- `markdownlint-cli` (pinned in `.github/workflows/` or `package.json`)
+
+### Test frameworks and coverage
+
+- `pytest`
+- `coverage`
+- `pytest-cov` and any other test plugins
+
+### Build tools
+
+- `hatch`
+- `setuptools`
+- `uv`
+
+## Anchor review
+
+During every dependency update sweep, review existing anchored dependency
+records:
+
+1. Read each anchor record in the repository (typically in
+   `docs/dependency-anchors/` or equivalent).
+2. Check the exit criteria: has the upstream issue been fixed? Has the
+   blocking version been released?
+3. If exit criteria are met, remove the anchor, update the dependency, and
+   note the resolution in the anchor's tracking issue.
+4. If exit criteria are not met, leave the anchor in place and add a
+   re-test comment to the tracking issue noting the date and current
+   upstream status.
+
+## Validation
+
+After all updates in a category (or after all categories if batching):
+
+```bash
+st-validate-local
+```
+
+`st-validate-local` is a host orchestrator that dispatches its inner
+validators into the container via `st-docker-run`. Invoke it directly —
+do not wrap it in `st-docker-run`. Fix any failures before proceeding to
+the next category or to submission.
 
 ## Failure handling
 
-- Determine root cause before pinning or deferring.
-- If a dependency is anchored below the latest acceptable range:
-  - Create or update an anchored dependency record.
-  - Document the failure evidence and exit criteria.
-- If the dependency itself is the blocker, create a tracking issue and record
-  the pin rationale at the source of truth.
+When a dependency update breaks validation:
 
-## Completion
+1. **Diagnose** — determine the root cause. Is it a breaking change in the
+   dependency, a bug in the new version, or a latent issue in the codebase?
+2. **Fix if possible** — if the fix is a straightforward code change (API
+   rename, import path change), apply it.
+3. **Anchor if not** — if the dependency cannot be updated without
+   significant work:
+   - Revert to the last working version.
+   - Create or update an anchored dependency record with:
+     - The dependency name and anchored version.
+     - The target version that failed.
+     - The exact failure evidence (error messages, test output).
+     - Exit criteria: what upstream change would unblock the update.
+   - File a tracking issue for the anchor if one does not exist.
+   - Link the anchor record to the tracking issue.
+4. **Never silently pin.** Every version hold must have a record and a
+   tracking issue.
 
-- Ensure the repository is in a clean, validated state.
-- Record any new anchors, issues, or follow-up actions.
+## Submission
+
+Once all applicable categories are updated and validation passes:
+
+1. Commit via `st-commit` with a message summarizing what was updated
+   (e.g., `chore(deps): sweep post-1.4.5 dependency updates`).
+2. Submit via the `pr-workflow` skill. The PR description should list
+   each category updated and any anchors created or resolved.
 
 ## Resources
 
-- `docs/repository/dependency-update-workflow.md`
-- `docs/repository/overview.md`
-- `docs/development/python/dependency-management.md` (when applicable)
-- `docs/code-management/pull-request-workflow.md`
+- `docs/repository/dependency-update-workflow.md` (in `standard-tooling`)
+- `docs/repository/overview.md` (in `standard-tooling`)
+- `docs/development/python/dependency-management.md` (in `standard-tooling`)
+- `docs/development/runtime-version-support-policy.md` (in `standard-tooling`)
+- `docs/development/documentation-toolchain.md` (in `standard-tooling`)
+- `skills/publish/SKILL.md` — Phase 5 and Dependency update categories
+- `skills/pr-workflow/SKILL.md` — for the submission step

--- a/skills/deprecation-triage/SKILL.md
+++ b/skills/deprecation-triage/SKILL.md
@@ -8,6 +8,7 @@ description: Triage deprecation warnings into a consistent workflow with issue t
 ## Table of Contents
 
 - [Overview](#overview)
+- [When to use](#when-to-use)
 - [Inputs](#inputs)
 - [Workflow](#workflow)
 - [Issue template](#issue-template)
@@ -17,6 +18,19 @@ description: Triage deprecation warnings into a consistent workflow with issue t
 
 Apply the deprecation warning triage policy to prevent warning drift and ensure
 issues are tracked and resolved in-cycle or deferred explicitly.
+
+## When to use
+
+The primary trigger is the `detect-deprecation-warnings` PostToolUse hook
+(`hooks/scripts/detect-deprecation-warnings.sh`). After any test command
+(`pytest`, `cargo test`, `go test`, etc.), the hook scans output for
+deprecation-warning patterns. When it finds one, it injects context telling the
+agent to invoke this skill after completing the current task.
+
+The skill can also be invoked directly via
+`/standard-tooling:deprecation-triage` when a deprecation warning surfaces
+outside the hook's scope (manual testing, log review, dependency changelog
+reading, etc.).
 
 ## Inputs
 

--- a/skills/project-issue/SKILL.md
+++ b/skills/project-issue/SKILL.md
@@ -31,37 +31,23 @@ Acceptance Criteria, Validation) and assigns the issue to a GitHub Project.
 
 ### Tooling
 
-This skill runs on the **host**. Almost all commands run inside the dev
-container via `st-docker-run`, which mounts the repo at `/workspace` and
-passes through `GH_TOKEN` and other environment variables automatically.
+This skill runs entirely on the **host**. All commands — `git`, `gh`,
+and the `st-*` CLI tools below — are host commands invoked directly
+without `st-docker-run` wrapping. They are thin Python wrappers around
+the GitHub API via `gh` / `GH_TOKEN`. See the
+[`publish` skill's host-vs-container section](../publish/SKILL.md#host-vs-container-commands)
+for the canonical split and rationale
+([#96](https://github.com/wphillipmoore/standard-tooling-plugin/issues/96)).
 
-**Host commands** — run directly:
+**Commands used:**
 
 - `git` — local git operations
+- `gh` — GitHub CLI (issue creation, project operations)
+- `st-list-project-repos` — list repos linked to a GitHub Project
+- `st-ensure-label` — create a label if it doesn't exist
+- `st-set-project-field` — set a field value on a project item
 
-**Container commands** — run via `st-docker-run`:
-
-- `gh` — all GitHub CLI operations
-- `st-list-project-repos`, `st-ensure-label`, `st-set-project-field`
-
-Search for `st-docker-run` in this order:
-
-1. `../standard-tooling/.venv-host/bin/st-docker-run` (sibling checkout
-   with host venv)
-2. `st-docker-run` on PATH (already installed)
-
-If neither is found, **abort** with a message directing the user to set up
-the host venv:
-
-```text
-st-docker-run not found. Run the following one-time setup:
-  cd ../standard-tooling
-  UV_PROJECT_ENVIRONMENT=.venv-host uv sync --group dev
-```
-
-Resolve `st-docker-run` once at the start of the workflow and use the
-resolved path for all subsequent container command invocations. Also verify
-`GH_TOKEN` is set in the environment before proceeding.
+Verify `GH_TOKEN` is set in the environment before proceeding.
 
 ### Interaction modes
 


### PR DESCRIPTION
# Pull Request

## Summary

- complete audit steps 6-7, align host/container routing

## Issue Linkage

- Ref #114

## Testing

- markdownlint

## Notes

- ## Summary

Complete audit steps 6-7 from #114 and align host/container routing per #96.

- **deprecation-triage** (step 6): Added "When to use" section that names the `detect-deprecation-warnings` PostToolUse hook as the primary trigger, closing the hook→skill seam gap.
- **dependency-update** (step 7): Full rewrite — encodes concrete commands per dependency category, `st-validate-local` as canonical validation, structured anchor review, explicit failure handling with anchored dependency records.
- **project-issue** (#96 alignment): Replaced stale Tooling section that routed `gh`, `st-list-project-repos`, `st-ensure-label`, `st-set-project-field` through `st-docker-run`. All are host commands.
- **skills-architecture.md**: Updated steps 5-7 status and Part 2 inventory entries.

Step 5 (project-issue scope expansion re: GitHub Projects) is deferred to a separate discussion.

## Test plan

- [x] `markdownlint .` passes
- [x] No remaining `st-docker-run -- <host-tool>` patterns in skills or agents
- [ ] Verify `dependency-update` skill drives a real update cycle correctly (next publish Phase 5)

Ref #114
Ref #96