### PR TITLE
feat(hooks): enforce host-vs-container tool routing per #96

### DIFF
--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -130,6 +130,37 @@ that *launch* the container cannot assume that environment.
 for key-value lookups. If you genuinely need associative arrays,
 the code belongs inside the container, not in host scripts.
 
+### enforce-host-container-split
+
+**What.** Checks the routing of every `st-*`, `gh`, `git`, and
+language-toolchain command against the canonical host-vs-container
+split from
+[#96](https://github.com/wphillipmoore/standard-tooling-plugin/issues/96).
+
+- **Denies** wrapping a host-only tool in `st-docker-run --`
+  (e.g., `st-docker-run -- gh issue list`). The host tool needs
+  SSH-agent, host git config, or host `gh` auth — the container
+  can't satisfy those.
+- **Warns** (via `additionalContext`, not deny) when a
+  container-only tool is invoked bare without `st-docker-run --`
+  (e.g., bare `ruff check .`). This sometimes works on hosts
+  with the tool installed but may silently use the wrong version.
+
+The canonical tool lists live in
+`hooks/scripts/lib/host-container-tools.sh` so the same source of
+truth powers both the hook and any future docs/lint.
+
+**Why.** The drift that produced #96 — 47 days of agents silently
+wrapping host tools in the container — was caused by documentation
+being the only enforcement mechanism. This hook makes the routing
+rule mechanical.
+
+**Alternative.** For denied commands: invoke the host tool
+directly (drop the `st-docker-run --` prefix). For warned
+commands: wrap the container tool in `st-docker-run --`. See the
+[`publish` skill's host-vs-container section](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/skills/publish/SKILL.md#host-vs-container-commands)
+for the canonical split and rationale.
+
 ## PreToolUse Hooks — Write|Edit
 
 *(none currently active — `block-memory-writes` was removed on

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -29,6 +29,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-associative-arrays.sh",
             "statusMessage": "Checking for bash associative arrays..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/enforce-host-container-split.sh",
+            "statusMessage": "Checking host/container tool routing..."
           }
         ]
       }

--- a/hooks/scripts/enforce-host-container-split.sh
+++ b/hooks/scripts/enforce-host-container-split.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# enforce-host-container-split.sh — PreToolUse hook for Bash.
+# Enforces the host-vs-container tool routing rule from #96.
+#
+# - DENY: wrapping a host-only tool in st-docker-run --
+# - WARN: bare-invoking a container-only tool without st-docker-run --
+#
+# Gated on managed-repo detection (#87): no-op in repos that lack
+# either docs/repository-standards.md or st-config.yaml.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/host-container-tools.sh"
+
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
+
+if ! is_managed_repo "$cwd"; then
+  exit 0
+fi
+
+command=$(echo "$input" | jq -r '.tool_input.command')
+
+# Check for host tools wrapped in st-docker-run -- (DENY)
+for tool in "${HOST_TOOLS[@]}"; do
+  if echo "$command" | grep -qE "(^|[;&|]\s*)st-docker-run\s+--\s+$tool(\s|$)"; then
+    jq -n --arg tool "$tool" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: ("\($tool) is a host command — invoke directly without st-docker-run wrapping. See issue #96: https://github.com/wphillipmoore/standard-tooling-plugin/issues/96")
+      }
+    }'
+    exit 0
+  fi
+done
+
+# Check for container tools invoked without st-docker-run -- (WARN)
+for tool in "${CONTAINER_TOOLS[@]}"; do
+  # Skip if the command already wraps the tool in st-docker-run
+  if echo "$command" | grep -qE "st-docker-run\s+--\s+$tool(\s|$)"; then
+    continue
+  fi
+  # Match bare invocation of the container tool
+  if echo "$command" | grep -qE "(^|[;&|]\s*)$tool(\s|$)"; then
+    jq -n --arg tool "$tool" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        additionalContext: ("WARNING: \($tool) is a container command — should be wrapped in st-docker-run --. See issue #96: https://github.com/wphillipmoore/standard-tooling-plugin/issues/96")
+      }
+    }'
+    exit 0
+  fi
+done
+
+exit 0

--- a/hooks/scripts/lib/host-container-tools.sh
+++ b/hooks/scripts/lib/host-container-tools.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# host-container-tools.sh — canonical tool routing lists per #96.
+#
+# Source of truth for which tools run on the host vs in the container.
+# Consumed by enforce-host-container-split.sh; kept here so the same
+# lists can power future docs/lint if needed.
+#
+# This file is meant to be `source`d, not executed directly.
+
+# Host-only: release/git workflow tools, thin gh/git wrappers.
+# shellcheck disable=SC2034
+HOST_TOOLS=(
+  st-prepare-release
+  st-commit
+  st-submit-pr
+  st-finalize-repo
+  st-merge-when-green
+  st-validate-local
+  st-docker-run
+  st-list-project-repos
+  st-ensure-label
+  st-set-project-field
+  gh
+  git
+  git-cliff
+  uv
+)
+
+# Container-only: language toolchain validators.
+# shellcheck disable=SC2034
+CONTAINER_TOOLS=(
+  ruff
+  mypy
+  ty
+  black
+  isort
+  markdownlint
+  st-markdown-standards
+  yamllint
+  actionlint
+  shellcheck
+  shfmt
+)


### PR DESCRIPTION
# Pull Request

## Summary

- enforce host-vs-container tool routing via PreToolUse hook

## Issue Linkage

- Fixes #98

## Testing

- markdownlint

## Notes

- New PreToolUse hook that mechanically enforces the #96 architectural split. Denies wrapping host tools (st-commit, gh, git, etc.) in st-docker-run. Warns on bare container tool invocations (ruff, markdownlint, etc.) without st-docker-run wrapping. Canonical tool lists in hooks/scripts/lib/host-container-tools.sh. Documented in docs/site/docs/hooks/index.md alongside existing block-* hooks.