### PR TITLE
chore(hooks): remove st-list-project-repos and st-set-project-field from host tools list

### DIFF
--- a/hooks/scripts/lib/host-container-tools.sh
+++ b/hooks/scripts/lib/host-container-tools.sh
@@ -17,9 +17,7 @@ HOST_TOOLS=(
   st-merge-when-green
   st-validate-local
   st-docker-run
-  st-list-project-repos
   st-ensure-label
-  st-set-project-field
   gh
   git
   git-cliff


### PR DESCRIPTION
# Pull Request

## Summary

- Remove dead project CLI tools from host-container routing list

## Issue Linkage

- Ref wphillipmoore/standard-tooling#335

## Testing

- markdownlint

## Notes

- -