### PR TITLE
docs(site): align docs tree with post-audit codebase state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ exception and stop.
 
 ## Shared Skills
 
-Replace `<standards-repo-path>` with the resolved local path when available.
-
-- Load all skills from: `<standards-repo-path>/skills/**/SKILL.md`
-- Treat every skill found under that directory as available and active.
+Skills are delivered by the `standard-tooling` plugin (this repo) via
+the Claude Code plugin system. Do **not** load skills from
+`standards-and-conventions` — that repo's `skills/` directory contains
+pre-migration copies that are stale or eliminated.
 
 ## Local Overrides
 

--- a/docs/development/starting-work-on-an-issue.md
+++ b/docs/development/starting-work-on-an-issue.md
@@ -172,28 +172,6 @@ working directory:
      --method POST -F sub_issue_id="$child_db_id"
    ```
 
-5. **Add to the parent's project** (if the parent is on a project):
-
-   ```bash
-   # Identify the parent's project
-   gh api graphql -f query='
-   {
-     repository(owner: "<parent_owner>", name: "<parent_repo>") {
-       issue(number: <parent_number>) {
-         projectItems(first: 5) {
-           nodes { project { number title } }
-         }
-       }
-     }
-   }'
-
-   # Add the new sub-issue to the same project
-   gh project item-add <project_number> \
-     --owner <owner> \
-     --url <child_issue_url> \
-     --format json --jq '.id'
-   ```
-
 Capture: `issue_number` — the repo-local number to use for
 worktree+branch creation.
 

--- a/docs/site/docs/agents/index.md
+++ b/docs/site/docs/agents/index.md
@@ -21,8 +21,8 @@ code changes are made.
 2. **Branch State** — reports the current branch and warns if on a protected
    branch (`main` or `develop`)
 
-3. **Standard Tooling CLI** — verifies `st-commit` is available on PATH
-   (expected inside the dev container)
+3. **Host Dispatcher** — verifies `st-docker-run` is available on PATH
+   (the host-side dispatcher for container-routed validation)
 
 4. **Standards and Conventions** — checks if the standards repo is available
    locally at `../standards-and-conventions`
@@ -39,7 +39,7 @@ Repository:    <repo name>
 Profile:       <repository_type> | <branching_model> | <primary_language>
 Branch:        <current branch> [WARNING if protected]
 Validation:    <validation command or "not configured">
-st-commit:     <available or "NOT FOUND">
+st-docker-run: <available or "NOT FOUND">
 Standards:     <local or web fallback>
 Git hooks:     <hooks path or "NOT CONFIGURED">
 =========================

--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -1,6 +1,6 @@
 # Hooks
 
-The plugin provides PreToolUse, PostToolUse, and Stop hooks that enforce
+The plugin provides PreToolUse and PostToolUse hooks that enforce
 workflow guardrails mechanically. These replace duplicated documentation
 rules across all consuming repos — rules that humans and agents
 alike routinely drift from when enforcement is prose-only.

--- a/docs/site/docs/index.md
+++ b/docs/site/docs/index.md
@@ -1,7 +1,7 @@
 # Standard Tooling Plugin
 
 Claude Code plugin for the standard-tooling ecosystem. Delivers shared hooks,
-skills, agents, and commands to all managed repositories.
+skills, and agents to all managed repositories.
 
 ## Overview
 
@@ -24,7 +24,7 @@ that enforces workflow compliance mechanically.
 |Repo|Delivers|Distribution|
 |---|---|---|
 |`standard-tooling`|Python CLIs (`st-*`), validators|PATH|
-|`standard-tooling-plugin`|Hooks, skills, agents, commands|Claude Code plugin|
+|`standard-tooling-plugin`|Hooks, skills, agents|Claude Code plugin|
 
 These are complementary: the plugin tells Claude how to behave; PATH makes the
 tools available to run.

--- a/docs/site/docs/skills/index.md
+++ b/docs/site/docs/skills/index.md
@@ -15,9 +15,9 @@ substantially change it.
 | Skill | Purpose | Status |
 |---|---|---|
 | [pr-workflow](#pr-workflow) | Submit a PR, wait for CI green, hand off to user; finalize after merge | Current |
-| [publish](#publish) | Drive library / tooling / documentation release flow | Needs review; rethink tracked in [#57](https://github.com/wphillipmoore/standard-tooling-plugin/issues/57) |
+| [publish](#publish) | Drive library / tooling / documentation release flow (Phases 1–7) | Current |
 | [project-issue](#project-issue) | Create a well-structured GitHub issue via guided questions | Current |
-| [dependency-update](#dependency-update) | Run the dependency-update workflow | Current (reviewed 2026-04-23, no changes) |
+| [dependency-update](#dependency-update) | Run the dependency-update workflow | Current |
 | [deprecation-triage](#deprecation-triage) | Triage deprecation warnings into tracking issues | Current (reviewed 2026-04-23, no changes) |
 | [summarize](#summarize) | Decision / operation / stream-of-consciousness summaries; SOC mode is the canonical capture for the fleet | Current |
 
@@ -53,25 +53,21 @@ tracking.
 of a repository that uses the `library-release` or
 `tagged-release` model.
 
-**Status.** Needs review. The dockerized validation model
-(everything runs via `st-docker-run`) and the recent publish-
-workflow changes in individual repos may have drifted from what
-this skill describes. Rethink tracked in
-[plugin#57](https://github.com/wphillipmoore/standard-tooling-plugin/issues/57)
-— applies lessons from the first-ever
-standard-tooling-plugin release exercise.
+**Status.** Current. Reflects the seven-phase release flow as of
+v1.4.5: Phase 4 verifies both `publish.yml` and `docs.yml`
+(#84); Phase 6 closes the tracking issue with a summary (#83);
+Phase 7 surfaces the consumer-refresh sequence (#105). The
+host-vs-container split is documented in the skill's own
+reference section.
 
 ## project-issue
 
 **What it does.** Guided issue creation that collects issue type,
-priority, work type, summary, problem/goal, acceptance criteria,
-and validation steps. Creates the issue in the target repo and
-adds it to the appropriate GitHub Project with the right field
-values set.
+summary, problem/goal, acceptance criteria, and validation steps.
+Creates the issue in the target repo with a label.
 
-**When to use.** When creating a new tracked issue, especially
-when it belongs on a GitHub Project board and needs standard
-fields populated.
+**When to use.** When creating a new tracked issue that needs
+standard fields populated consistently.
 
 **Status.** Current.
 
@@ -89,12 +85,13 @@ below the latest acceptable range.
 response to a CVE, a scheduled cycle, or as part of normal
 maintenance.
 
-**Status.** Current. Reviewed for currency on 2026-04-23 as part
-of [plugin#59](https://github.com/wphillipmoore/standard-tooling-plugin/issues/59);
-no changes needed. References `docs/repository/dependency-update-workflow.md`
-and sibling docs that may not exist in every consuming repo — those
-references are informational (consult if present) rather than
-required.
+**Status.** Current. Rewritten as part of the skills audit
+([#114](https://github.com/wphillipmoore/standard-tooling-plugin/issues/114))
+with concrete per-category commands (Python deps via `uv lock`,
+CI action pins, runtime versions, doc toolchain, linters, build
+tools), `st-validate-local` as the canonical validation step,
+structured failure handling via anchored dependency records, and
+anchor review as a first-class section.
 
 ## deprecation-triage
 


### PR DESCRIPTION
# Pull Request

## Summary

- Align docs tree with post-audit codebase state

## Issue Linkage

- Fixes #134

## Testing

- markdownlint

## Notes

- Eight docs-tree fixes after the v1.4.x audit cycle:

1. skills/index: publish status updated from needs-review to current (Phases 4/6/7 landed)
2. skills/index: project-issue description stripped of GitHub Projects references
3. skills/index: dependency-update status updated to reflect full rewrite
4. agents/index: bootstrap check 3 corrected from st-commit to st-docker-run
5. AGENTS.md: shared-skills section no longer loads stale copies from standards-and-conventions
6. site index: dropped commands from delivery list (commands/ is empty)
7. starting-work-on-an-issue: removed sub-issue project-add step (Projects stripped)
8. hooks/index: opening line corrected to remove Stop hooks (none active)