### PR TITLE
fix(site): shorten mkdocs.yml site_description and drop stale commands reference

### DIFF
--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: Standard Tooling Plugin
-site_description: Claude Code plugin delivering shared hooks, skills, agents, and commands for the standard-tooling ecosystem
+site_description: >-
+  Claude Code plugin delivering shared hooks, skills, and agents
+  for the standard-tooling ecosystem
 repo_url: https://github.com/wphillipmoore/standard-tooling-plugin
 repo_name: wphillipmoore/standard-tooling-plugin
 


### PR DESCRIPTION
# Pull Request

## Summary

- Shorten site_description to fix yamllint line-length and drop stale commands reference

## Issue Linkage

- Fixes #138

## Testing

- markdownlint

## Notes

- -