### PR TITLE
feat(hooks): forbid auto-close linkage, require Ref and explicit issue closure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@
 
 ## Issue Linkage
 
-- Fixes # (default; use when no acceptance criteria exist)
-- Ref # (use when acceptance criteria exist)
-- Work is not complete until the issue is closed.
+- Ref #
+- Do not use `Fixes`, `Closes`, or `Resolves` — issues are closed
+  explicitly after finalization, not auto-closed at merge time.
 - If no issue exists, open one before any work begins.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ for the rationale.
 | `block-protected-branch-work` | PreToolUse/Bash | Blocks commits from outside `.worktrees/*` on repos that adopt the worktree convention; otherwise blocks commits on `develop`/`main` |
 | `block-heredoc` | PreToolUse/Bash | Blocks `<<EOF` in CLI args (use `--body-file` or `$(cat <file>)`) |
 | `block-associative-arrays` | PreToolUse/Bash | Blocks bash 4+ associative arrays — host scripts must run on macOS bash 3.2 |
+| `enforce-host-container-split` | PreToolUse/Bash | Denies wrapping host-only tools in `st-docker-run`; warns on bare container-only tools |
+| `block-autoclose-linkage` | PreToolUse/Bash | Blocks `--linkage Fixes/Closes/Resolves` in `st-submit-pr` — use `Ref` instead |
 | `remind-finalize` | PostToolUse/Bash | After `st-submit-pr`, reminds to run `st-finalize-repo` |
 | `detect-deprecation-warnings` | PostToolUse/Bash | Surfaces deprecation warnings from test output for triage |
 

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -97,7 +97,10 @@ st-submit-pr \
 
 - `--issue` (required): GitHub issue number (just the number)
 - `--summary` (required): one-line PR summary
-- `--linkage` (optional, default: `Fixes`): `Fixes|Closes|Resolves|Ref`
+- `--linkage` (optional, default: `Ref`): **always use `Ref`**.
+  `Fixes`, `Closes`, and `Resolves` are forbidden — they auto-close
+  the issue at merge time, bypassing finalization. Issues are closed
+  explicitly after `st-finalize-repo` succeeds.
 - `--title` (optional): PR title (default: most recent commit subject)
 - `--notes` (optional): additional notes
 - `--dry-run` (optional): print generated PR without executing

--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -161,6 +161,26 @@ commands: wrap the container tool in `st-docker-run --`. See the
 [`publish` skill's host-vs-container section](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/skills/publish/SKILL.md#host-vs-container-commands)
 for the canonical split and rationale.
 
+### block-autoclose-linkage
+
+**What.** Denies `st-submit-pr` invocations that pass `--linkage
+Fixes`, `--linkage Closes`, or `--linkage Resolves`.
+
+**Why.** These keywords auto-close the linked issue when the PR
+merges. Our workflow has a mandatory post-merge finalization phase
+(`st-finalize-repo`) that reconciles local state — an issue closed
+at merge time signals "done" while the local environment is stale.
+Using `Ref` linkage keeps the issue open until finalization
+confirms the work cycle is complete, at which point the agent
+closes the issue explicitly.
+
+**Alternative.** Use `--linkage Ref` (or omit `--linkage` — `Ref`
+is the intended default once `st-submit-pr` is updated in
+`standard-tooling`). After `st-finalize-repo` succeeds, close the
+issue with `gh issue close <N>`. The
+[`pr-workflow` skill](../skills/index.md#pr-workflow)'s "Close the
+issue" step documents this flow.
+
 ## PreToolUse Hooks — Write|Edit
 
 *(none currently active — `block-memory-writes` was removed on

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -34,6 +34,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/enforce-host-container-split.sh",
             "statusMessage": "Checking host/container tool routing..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-autoclose-linkage.sh",
+            "statusMessage": "Checking for auto-close linkage keywords..."
           }
         ]
       }

--- a/hooks/scripts/block-autoclose-linkage.sh
+++ b/hooks/scripts/block-autoclose-linkage.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# block-autoclose-linkage.sh — PreToolUse hook for Bash.
+# Blocks st-submit-pr invocations that use auto-close linkage keywords
+# (Fixes, Closes, Resolves). Use --linkage Ref instead.
+#
+# Gated on managed-repo detection (#87): no-op in repos that lack
+# either docs/repository-standards.md or st-config.yaml.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
+
+if ! is_managed_repo "$cwd"; then
+  exit 0
+fi
+
+command=$(echo "$input" | jq -r '.tool_input.command')
+
+if echo "$command" | grep -qE 'st-submit-pr\b'; then
+  if echo "$command" | grep -qiE -- '--linkage\s+(Fixes|Closes|Resolves)\b'; then
+    jq -n '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: "Auto-close linkage keywords (Fixes, Closes, Resolves) are forbidden. Use --linkage Ref instead. Issues are closed explicitly after st-finalize-repo confirms the work cycle is complete. See issue #126."
+      }
+    }'
+    exit 0
+  fi
+fi
+
+exit 0

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -84,10 +84,11 @@ for the canonical split.
 3. If any check fails, **do not submit** the PR. Fix the failures
    and re-run validation. Loop until clean.
 4. Populate the PR template fields. Required:
-   - Issue linkage using a standard GitHub keyword: `Fixes #N`,
-     `Closes #N`, `Resolves #N` (all auto-close on merge), or
-     `Ref #N` (non-closing; use when acceptance criteria still
-     apply or when the issue should outlive the merge).
+   - Issue linkage using `Ref #N`. **Do not use `Fixes`, `Closes`,
+     or `Resolves`** — those keywords auto-close the issue on
+     merge, bypassing finalization. Issues are closed explicitly
+     after `st-finalize-repo` confirms the work cycle is complete.
+     The `block-autoclose-linkage` hook enforces this mechanically.
 
 ## Submission
 
@@ -99,7 +100,7 @@ opens the PR. Example invocation shape:
 st-submit-pr \
   --issue <N> \
   --summary "<one-line summary>" \
-  --linkage <Fixes|Closes|Resolves|Ref> \
+  --linkage Ref \
   --notes "<PR body content; pass multi-line via $(cat <file>) per the
            shell command policy in CLAUDE.md>"
 ```
@@ -221,6 +222,26 @@ For each workflow in the table:
 
 If the repository profile lists no post-merge async workflows,
 skip this step.
+
+### Close the issue
+
+After finalization and post-merge workflow verification both
+succeed, close the linked issue:
+
+```bash
+gh issue close <N> --comment "Closed after finalization. PR: <pr-url>"
+```
+
+Issue closure happens here — not at merge time — because the work
+cycle is not complete until `st-finalize-repo` has reconciled
+local state. The `Ref #N` linkage used at submission time
+deliberately avoids auto-close so this explicit step is the only
+path to closure.
+
+If the PR used `Ref` (non-closing) linkage against an issue whose
+acceptance criteria span multiple PRs, **do not close the issue**.
+Only close when this PR completes the final piece of work the
+issue tracks.
 
 This concludes the work cycle.
 


### PR DESCRIPTION
# Pull Request

## Summary

- Forbid auto-close linkage keywords, require Ref and explicit issue closure after finalization

## Issue Linkage

- Ref #126

## Testing

- markdownlint

## Notes

- Cross-repo follow-up from wphillipmoore/standard-tooling-plugin#126.

Change the default `--linkage` value in `st-submit-pr` from `Fixes` to
`Ref`. The plugin-side enforcement (the `block-autoclose-linkage` hook) is
already in place; this change aligns the CLI default so agents that omit
`--linkage` get `Ref` automatically instead of being blocked by the hook.

Optionally gate `Fixes`, `Closes`, and `Resolves` behind a `--force`
flag or remove them entirely — the plugin hook denies them regardless, so
the CLI accepting them just creates a confusing deny-after-accept UX.


Cross-repo follow-ups:
- standard-tooling#356: change st-submit-pr default --linkage from Fixes to Ref
- standard-actions#247: CI check to reject auto-close keywords in PR bodies