### PR TITLE
fix(docs): remove non-existent /plugin update command from consumer-refresh sequence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,8 @@ markdownlint .
 When the user asks how to refresh / update / reinstall this plugin
 after a new release, the canonical sequence is in the README's
 [Update section](README.md#update). Do **not** guess or improvise —
-the sequence is three steps (`marketplace update` → `update` →
-`reload-plugins`) and each is required. The non-interactive CLI
-form is `claude plugin update <plugin>@<marketplace>`.
+the sequence is two steps (`marketplace update` → `reload-plugins`)
+and both are required.
 
 ## Development and deployment of this repo
 

--- a/README.md
+++ b/README.md
@@ -68,42 +68,24 @@ PATH first — see the Getting Started guide above.
 ## Update
 
 After a new release ships, refresh the local install with this
-three-step sequence. Each step is required — none of them are
-implied by the others.
+two-step sequence:
 
 ```text
 /plugin marketplace update standard-tooling-marketplace
-/plugin update standard-tooling@standard-tooling-marketplace
 /reload-plugins
 ```
 
 What each step does:
 
 1. **`/plugin marketplace update <marketplace>`** — refreshes the
-   marketplace index only. It tells Claude Code that a new version
-   exists; it does **not** download the new version.
-2. **`/plugin update <plugin>@<marketplace>`** — installs the new
-   version into the local cache at
-   `~/.claude/plugins/cache/<plugin-id>/<version>/`. The previous
-   version stays on disk for 7 days as a grace window for
-   concurrent sessions, then is removed automatically.
-3. **`/reload-plugins`** — applies the new skills / hooks / agents
+   marketplace index and downloads the new plugin version into the
+   local cache at `~/.claude/plugins/cache/<plugin-id>/<version>/`.
+   The previous version stays on disk for 7 days as a grace window
+   for concurrent sessions, then is removed automatically.
+2. **`/reload-plugins`** — applies the new skills / hooks / agents
    to the **current** Claude Code session without restarting.
    Without this, the running session keeps using the old in-memory
    plugin state.
-
-### Non-interactive form
-
-For scripts and one-liners (e.g., `claude` invocations from a
-deploy hook), the same install-side action runs as:
-
-```bash
-claude plugin update standard-tooling@standard-tooling-marketplace
-```
-
-After running it, any **new** Claude Code session you start picks
-up the new version automatically. Existing sessions still need
-`/reload-plugins`.
 
 ### Verify the update
 

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -411,8 +411,9 @@ the bookkeeping is still done.
 The release artifacts are published, but **consumers haven't
 picked them up yet.** Every Claude Code session that has this
 plugin (or any standard-tooling-distributed plugin) installed
-needs an explicit local refresh — neither `docker run` nor
-`/plugin marketplace update` auto-pulls fresh content. The agent
+needs an explicit local refresh — `/plugin marketplace update`
+downloads the new version but the running session keeps using the
+old in-memory state until `/reload-plugins` is run. The agent
 producing the release is responsible for surfacing the refresh
 step explicitly to the user. Listing artifacts and stopping is
 not the end of the cycle; saying "v\<version> shipped, now run
@@ -423,7 +424,6 @@ repo (`standard-tooling-plugin`):
 
 ```text
 /plugin marketplace update standard-tooling-marketplace
-/plugin update standard-tooling@standard-tooling-marketplace
 /reload-plugins
 ```
 


### PR DESCRIPTION
# Pull Request

## Summary

- Remove non-existent /plugin update command from consumer-refresh sequence

## Issue Linkage

- Ref #150

## Testing

- markdownlint

## Notes

- The three-step refresh sequence included a /plugin update command that does not exist in Claude Code. Running it drops into the generic /plugin menu with no effect. The marketplace update command already downloads the new version into the local cache, making step 2 both broken and redundant. Fixed in README.md, CLAUDE.md, and skills/publish/SKILL.md.