### PR TITLE
feat: add block-agent-merge PreToolUse hook

### DIFF
--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -181,6 +181,34 @@ issue with `gh issue close <N>`. The
 [`pr-workflow` skill](../skills/index.md#pr-workflow)'s "Close the
 issue" step documents this flow.
 
+### block-agent-merge
+
+**What.** Denies Bash tool invocations that call `gh pr merge`
+or `gh pr review --approve` on non-release PRs.
+
+**Why.** Agents must not merge feature or bugfix PRs — human
+review and merge is required. Skill prose saying "do not merge"
+is advisory; agents rationalize past it. This hook makes the
+rule mechanical. See
+[#162](https://github.com/wphillipmoore/standard-tooling-plugin/issues/162)
+for the incident that motivated this.
+
+**How it works.** The hook delegates branch verification to
+`st-check-pr-merge`, which resolves the PR's head branch via the
+GitHub API and checks it against the release-workflow allow-list
+(`release/*` and `chore/bump-version-*`). Exit codes follow the
+three-state convention
+([standard-tooling#373](https://github.com/wphillipmoore/standard-tooling/issues/373)):
+0 = allowed, 1 = denied, 2 = unknown. The unknown case still
+blocks the merge, but the reason message distinguishes "denied by
+policy" from "tool failed" so the user knows whether to investigate
+a policy question or a tooling failure.
+
+**Alternative.** Hand off the PR URL to the user for review and
+merge. For release-workflow PRs (`release/*` and
+`chore/bump-version-*`), use `st-merge-when-green` from the
+[`publish` skill](../skills/index.md#publish).
+
 ## PreToolUse Hooks — Write|Edit
 
 *(none currently active — `block-memory-writes` was removed on

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -39,6 +39,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-autoclose-linkage.sh",
             "statusMessage": "Checking for auto-close linkage keywords..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/block-agent-merge.sh",
+            "statusMessage": "Checking for unauthorized PR merge..."
           }
         ]
       }

--- a/hooks/scripts/block-agent-merge.sh
+++ b/hooks/scripts/block-agent-merge.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# block-agent-merge.sh — PreToolUse hook for Bash.
+# Blocks gh pr merge and gh pr review --approve on non-release PRs.
+# Delegates branch verification to st-check-pr-merge.
+#
+# Gated on managed-repo detection (#87): no-op in repos that lack
+# either docs/repository-standards.md or st-config.yaml.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
+
+if ! is_managed_repo "$cwd"; then
+  exit 0
+fi
+
+command=$(echo "$input" | jq -r '.tool_input.command')
+
+if ! echo "$command" \
+     | grep -qE '(^|[;&|]\s*)gh\s+pr\s+(merge(\s|$)|review\s+.*--approve)'; then
+  exit 0
+fi
+
+rc=0
+stderr=$(st-check-pr-merge "$command" 2>&1 1>/dev/null) || rc=$?
+if [ "$rc" -eq 0 ]; then
+  exit 0
+fi
+
+if [ "$rc" -eq 1 ]; then
+  reason="${stderr:-Denied by st-check-pr-merge (no details provided).}"
+elif [ "$rc" -eq 2 ]; then
+  reason="st-check-pr-merge could not determine whether this merge is allowed (exit 2). Error: ${stderr:-no details}. Resolve the tool failure before retrying."
+else
+  reason="st-check-pr-merge exited with unexpected code $rc. Error: ${stderr:-no details}. Cannot determine whether this merge is allowed."
+fi
+
+jq -n --arg reason "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'


### PR DESCRIPTION
# Pull Request

## Summary

- Add block-agent-merge PreToolUse hook

## Issue Linkage

- Ref #162

## Testing

- markdownlint

## Notes

- Phase 3 of the block-agent-merge feature (standard-tooling-plugin#162).

New PreToolUse hook that mechanically prevents agents from merging non-release PRs. Replaces advisory skill prose with a hard gate.

Changes:
- New `hooks/scripts/block-agent-merge.sh`: detects `gh pr merge` and `gh pr review --approve` commands, delegates to `st-check-pr-merge` for branch verification, handles three-state exit codes (0=allowed, 1=denied, 2=unknown) with distinct messages for each
- Registered in `hooks/hooks.json` under PreToolUse > Bash
- Documented in `docs/site/docs/hooks/index.md`

Depends on `st-check-pr-merge` from standard-tooling (shipped in standard-tooling PR #378).