### PR TITLE
feat: add st-docker-cache and st-config.toml support to workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ Sourced from the official Claude Code documentation:
 PreToolUse, PostToolUse, and Stop hooks that enforce guardrails
 mechanically. Every hook below **except `block-heredoc`** is
 gated on a managed-repo check: a repo must contain either
-`docs/repository-standards.md` or `st-config.yaml` at its root for
-the hook to fire. In repos without either marker, the gated hooks
+`docs/repository-standards.md`, `st-config.toml`, or
+`st-config.yaml` at its root for the hook to fire. In repos
+without any marker, the gated hooks
 short-circuit to a no-op so the plugin doesn't interfere with
 ad-hoc git work in unrelated repositories. See the
 [hooks reference](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md#managed-repo-gating)

--- a/docs/development/starting-work-on-an-issue.md
+++ b/docs/development/starting-work-on-an-issue.md
@@ -55,6 +55,13 @@ git worktree add ".worktrees/issue-${N}-${SLUG}" \
   -b "${TYPE}/${N}-${SLUG}" origin/develop
 ```
 
+Pre-warm the dev container cache for the new branch so the first
+`st-docker-run` invocation is fast:
+
+```bash
+cd ".worktrees/issue-${N}-${SLUG}" && st-docker-cache build
+```
+
 Then either:
 
 - **Continue in the current session.** Use the worktree's absolute

--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -19,17 +19,18 @@ to achieve the intent correctly when the hook blocks you.
 ## Managed-repo gating
 
 Every hook below **except `block-heredoc`** is gated on a
-managed-repo check. A repo is "managed" when either of these marker
+managed-repo check. A repo is "managed" when any of these marker
 files exists at the repo root:
 
 - `docs/repository-standards.md` — the existing per-repo config
-- `st-config.yaml` — the future single-file config (transition target;
-  both are accepted during migration)
+- `st-config.toml` — the single-file config
+- `st-config.yaml` — legacy variant (both formats accepted during
+  migration)
 
-When neither marker is present, the gated hooks short-circuit to a
+When no marker is present, the gated hooks short-circuit to a
 no-op so the plugin doesn't interfere with ad-hoc git work in
 unrelated repositories. Detection is a pure-shell walk up from the
-bash session's CWD looking for either marker, terminating at a
+bash session's CWD looking for any marker, terminating at a
 `.git` boundary or the filesystem root. No `git` subprocess; the
 gate's overhead is a handful of `stat()` calls.
 

--- a/hooks/scripts/lib/managed-repo-check.sh
+++ b/hooks/scripts/lib/managed-repo-check.sh
@@ -5,8 +5,8 @@
 # is the presence of either of two marker files at the repo root:
 #
 #   docs/repository-standards.md   — the existing per-repo config
-#   st-config.yaml                 — the future single-file config
-#                                    (transition target; both are
+#   st-config.toml                 — the single-file config
+#   st-config.yaml                 — legacy variant (both formats
 #                                    accepted during migration)
 #
 # When neither marker is present, the plugin's enforcement hooks
@@ -35,8 +35,8 @@
 #   3. The walk reaches `/` or an empty path → return 1 (not managed).
 #
 # Implementation note: pure shell. No subprocess spawns (no `git`,
-# no `dirname`, no `realpath`). Each iteration is two `[ -f ]` and
-# one `[ -e ]` — sub-millisecond per call.
+# no `dirname`, no `realpath`). Each iteration is three `[ -f ]`
+# and one `[ -e ]` — sub-millisecond per call.
 is_managed_repo() {
 	local dir="${1:-$PWD}"
 
@@ -47,7 +47,7 @@ is_managed_repo() {
 	esac
 
 	while [ "$dir" != "/" ] && [ -n "$dir" ]; do
-		if [ -f "$dir/docs/repository-standards.md" ] || [ -f "$dir/st-config.yaml" ]; then
+		if [ -f "$dir/docs/repository-standards.md" ] || [ -f "$dir/st-config.toml" ] || [ -f "$dir/st-config.yaml" ]; then
 			return 0
 		fi
 		if [ -e "$dir/.git" ]; then

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -79,6 +79,9 @@ for the canonical split.
 - Ensure commit-message format and AI co-authorship requirements
   are met per the commit standards (handled by `st-commit`; this
   skill does not commit).
+- If `st-docker-cache` is available, run `st-docker-cache build`
+  to ensure the cached dev container image is warm for validation.
+  This is a no-op if the cache is already current.
 
 ## Pre-submission
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add st-docker-cache and st-config.toml support to workflows

## Issue Linkage

- Ref #172

## Testing

- markdownlint

## Notes

- Integrates the cache-first architecture from standard-tooling#362 into the plugin's workflow skills.

Changes:
- starting-work-on-an-issue.md: added st-docker-cache build step after worktree creation to pre-warm the cached image
- pr-workflow SKILL.md: added st-docker-cache build to preflight checklist
- managed-repo-check.sh: added st-config.toml as a managed-repo marker (alongside existing st-config.yaml and docs/repository-standards.md)
- hooks/index.md and README.md: updated managed-repo gating docs to list all three marker files