### PR TITLE
fix(hooks): redirect container-tool warning to st-validate-local abstraction layer

### DIFF
--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -143,9 +143,11 @@ split from
   SSH-agent, host git config, or host `gh` auth — the container
   can't satisfy those.
 - **Warns** (via `additionalContext`, not deny) when a
-  container-only tool is invoked bare without `st-docker-run --`
-  (e.g., bare `ruff check .`). This sometimes works on hosts
-  with the tool installed but may silently use the wrong version.
+  container-only tool is invoked directly — whether bare
+  (e.g., `ruff check .`) or wrapped in `st-docker-run --`.
+  Both bypass the `scripts/dev/*.sh` abstraction layer that
+  each repo maintains. The correct entry point is
+  `st-validate-local`, which delegates to those scripts.
 
 The canonical tool lists live in
 `hooks/scripts/lib/host-container-tools.sh` so the same source of
@@ -153,12 +155,17 @@ truth powers both the hook and any future docs/lint.
 
 **Why.** The drift that produced #96 — 47 days of agents silently
 wrapping host tools in the container — was caused by documentation
-being the only enforcement mechanism. This hook makes the routing
-rule mechanical.
+being the only enforcement mechanism. Issue
+[#168](https://github.com/wphillipmoore/standard-tooling-plugin/issues/168)
+extended this to also catch agents bypassing the `scripts/dev`
+abstraction by calling linters directly (even correctly wrapped in
+`st-docker-run`). The agent should never invoke individual
+linters — `st-validate-local` handles tool routing internally.
 
 **Alternative.** For denied commands: invoke the host tool
 directly (drop the `st-docker-run --` prefix). For warned
-commands: wrap the container tool in `st-docker-run --`. See the
+commands: use `st-validate-local` instead of invoking individual
+linters. See the
 [`publish` skill's host-vs-container section](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/skills/publish/SKILL.md#host-vs-container-commands)
 for the canonical split and rationale.
 

--- a/hooks/scripts/enforce-host-container-split.sh
+++ b/hooks/scripts/enforce-host-container-split.sh
@@ -38,18 +38,13 @@ for tool in "${HOST_TOOLS[@]}"; do
   fi
 done
 
-# Check for container tools invoked without st-docker-run -- (WARN)
+# Check for container tools invoked directly (WARN)
 for tool in "${CONTAINER_TOOLS[@]}"; do
-  # Skip if the command already wraps the tool in st-docker-run
-  if echo "$command" | grep -qE "st-docker-run\s+--\s+$tool(\s|$)"; then
-    continue
-  fi
-  # Match bare invocation of the container tool
-  if echo "$command" | grep -qE "(^|[;&|]\s*)$tool(\s|$)"; then
+  if echo "$command" | grep -qE "(^|[;&|]\s*)(st-docker-run\s+--\s+)?$tool(\s|$)"; then
     jq -n --arg tool "$tool" '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        additionalContext: ("WARNING: \($tool) is a container command — should be wrapped in st-docker-run --. See issue #96: https://github.com/wphillipmoore/standard-tooling-plugin/issues/96")
+        additionalContext: ("WARNING: \($tool) should not be invoked directly. Use st-validate-local for validation — it delegates to scripts/dev/*.sh which handle tool routing internally. See issue #168: https://github.com/wphillipmoore/standard-tooling-plugin/issues/168")
       }
     }'
     exit 0


### PR DESCRIPTION
# Pull Request

## Summary

- Redirect container-tool warning to st-validate-local abstraction layer

## Issue Linkage

- Ref #168

## Testing

- markdownlint

## Notes

- The enforce-host-container-split hook previously warned agents to wrap container tools in `st-docker-run --`. This was the wrong guidance — calling `st-docker-run -- ruff check .` still bypasses the `scripts/dev/*.sh` abstraction layer that each repo maintains.

Changes:

- **enforce-host-container-split.sh**: Consolidated the container-tool check into a single regex that catches both bare invocations and `st-docker-run`-wrapped invocations. Warning message now redirects agents to `st-validate-local` instead of suggesting `st-docker-run` wrapping.
- **hooks/index.md**: Updated the enforce-host-container-split documentation to reflect the new warning behavior and rationale from #168.