### PR TITLE
chore(ci): remove duplicate ci: markdownlint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
 
   # ---------------------------------------------------------------------------
-  # Quality: shellcheck, markdownlint, mkdocs-build
+  # Quality: shellcheck, mkdocs-build
   # ---------------------------------------------------------------------------
 
   shellcheck:
@@ -39,21 +39,6 @@ jobs:
           else
             echo "No shell scripts found."
           fi
-
-  markdownlint:
-    name: "ci: markdownlint"
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:3.14
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Mark workspace safe for git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Run markdownlint
-        run: markdownlint 'docs/site/**/*.md' 'README.md'
 
   mkdocs-build:
     name: "ci: mkdocs-build"


### PR DESCRIPTION
# Pull Request

## Summary

- Remove duplicate ci: markdownlint job

## Issue Linkage

- Ref #174

## Testing

- markdownlint

## Notes

- The `ci: markdownlint` job in CI duplicated (with a narrower scope) what `st-validate-local-common` already runs through the `standards-compliance` action. Both covered `docs/site/**/*.md` and `README.md` — the CI job added no additional coverage.

Changes:

- Removed the `markdownlint` job from `.github/workflows/ci.yml`
- Removed `ci: markdownlint` from the CI gates ruleset (required status checks)

The coverage gap for `docs/plans/` and other non-site markdown is tracked separately in standard-actions#260.