### PR TITLE
fix(docs): fix line-length violations in block-agent-merge plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,6 @@ obligation to surface the consumer-refresh sequence to the user
 at release time.
 
 When you complete a publish, **the cycle is not done until you
-have shown the user the three-step refresh sequence.** Listing
+have shown the user the two-step refresh sequence.** Listing
 artifacts and stopping is a regression on
 [#105](https://github.com/wphillipmoore/standard-tooling-plugin/issues/105).

--- a/docs/plans/block-agent-merge.md
+++ b/docs/plans/block-agent-merge.md
@@ -313,11 +313,16 @@ there — just confirm it doesn't claim to be exhaustive).
 No automated test framework for hook scripts in this repo.
 Manual verification per the spec's test plan:
 
-1. **Block case:** Pipe `{"tool_input":{"command":"gh pr merge 42","cwd":"/path/to/managed-repo"}}` to the script with `st-check-pr-merge` returning non-zero. Expect deny JSON.
-2. **Allow case:** Same input with `st-check-pr-merge` returning 0. Expect exit 0, no output.
-3. **Non-managed repo:** Input with a cwd lacking marker files. Expect exit 0.
+1. **Block case:** Pipe a JSON payload containing `gh pr merge 42`
+   to the script with `st-check-pr-merge` returning non-zero.
+   Expect deny JSON.
+2. **Allow case:** Same input with `st-check-pr-merge` returning
+   0. Expect exit 0, no output.
+3. **Non-managed repo:** Input with a cwd lacking marker files.
+   Expect exit 0.
 4. **No match:** Input with `gh issue list`. Expect exit 0.
-5. **`gh pr review --approve`:** Input with review command, `st-check-pr-merge` returning non-zero. Expect deny JSON.
+5. **`gh pr review --approve`:** Input with review command,
+   `st-check-pr-merge` returning non-zero. Expect deny JSON.
 
 ## Cross-repo coordination
 

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -427,11 +427,14 @@ picked them up yet.** Every Claude Code session that has this
 plugin (or any standard-tooling-distributed plugin) installed
 needs an explicit local refresh — `/plugin marketplace update`
 downloads the new version but the running session keeps using the
-old in-memory state until `/reload-plugins` is run. The agent
-producing the release is responsible for surfacing the refresh
-step explicitly to the user. Listing artifacts and stopping is
-not the end of the cycle; saying "v\<version> shipped, now run
-the refresh sequence" is.
+old in-memory state until `/reload-plugins` is run.
+
+**Display only — do not execute.** The agent's job is to show
+the user the exact commands to run, not to run them. The refresh
+is a consumer-side action: the user controls when and in which
+session they apply it. Running the commands silently or
+inconsistently (sometimes executing, sometimes displaying) is
+the behavior this rule exists to prevent.
 
 Surface the consumer-side update sequence verbatim. For this
 repo (`standard-tooling-plugin`):
@@ -442,11 +445,11 @@ repo (`standard-tooling-plugin`):
 ```
 
 For other tool-providing repos (`standard-tooling`,
-`standard-tooling-docker`, `standard-actions`), use the
-repo-specific refresh sequence — see each repo's `Development
-and deployment` section in its README. If the repo doesn't
-document a refresh sequence, that's a gap to file separately;
-do not invent one.
+`standard-tooling-docker`, `standard-actions`), look up the
+repo-specific refresh sequence from the repo's `Development
+and deployment` section in its README and display it verbatim.
+If the repo doesn't document a refresh sequence, that's a gap
+to file separately; do not invent one.
 
 Phase 7 ends when the user has seen the refresh sequence in the
 hand-off message. The user is not required to *run* the


### PR DESCRIPTION
# Pull Request

## Summary

- Make Phase 7 hand-off display-only, fix stale references and lint

## Issue Linkage

- Ref #180

## Testing

- markdownlint

## Notes

- Phase 7 of the publish skill was ambiguous about whether the agent should execute the consumer-refresh commands or just display them. This led to inconsistent behavior across releases — sometimes running, sometimes telling the user to run.

Changes:

- **skills/publish/SKILL.md**: Added explicit "Display only — do not execute" rule to Phase 7 with rationale. The agent shows the exact commands; the user controls when and where to run them.
- **CLAUDE.md**: Fixed stale "three-step refresh sequence" reference to "two-step" (the middle command was removed in a prior fix).