### PR TITLE
feat(skills): use st-wait-until-green in pr-workflow, add to host tools

### DIFF
--- a/hooks/scripts/lib/host-container-tools.sh
+++ b/hooks/scripts/lib/host-container-tools.sh
@@ -15,6 +15,7 @@ HOST_TOOLS=(
   st-submit-pr
   st-finalize-repo
   st-merge-when-green
+  st-wait-until-green
   st-validate-local
   st-docker-run
   st-ensure-label

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -134,10 +134,10 @@ of latency for nothing.
 Poll the PR's required checks:
 
 ```bash
-gh pr checks <pr-url> --watch --required
+st-wait-until-green <pr-url>
 ```
 
-`gh pr checks --watch` blocks until all required checks complete
+`st-wait-until-green` blocks until all required checks complete
 and exits non-zero if any required check failed.
 
 ### If checks pass

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -71,7 +71,8 @@ a seam that can break.
 - `git` — local git operations (checkout, branch, fetch, pull, push)
 - `gh` — all GitHub CLI operations (issue/PR/release management)
 - `st-prepare-release`, `st-commit`, `st-submit-pr`, `st-finalize-repo`,
-  `st-merge-when-green` — release/PR lifecycle drivers
+  `st-merge-when-green`, `st-wait-until-green` — release/PR lifecycle
+  drivers
 - `st-docker-run` itself — the dispatcher that runs container commands
 - `git-cliff` — changelog generation
 
@@ -147,8 +148,9 @@ within a single session.
 - Identify the canonical validation command from the repository profile.
 - Locate the standard-tooling host commands using the search algorithm
   above (at minimum: `st-prepare-release`, `st-merge-when-green`,
-  `st-finalize-repo`, `st-commit`, `st-submit-pr`, `gh`, `git-cliff`,
-  `st-docker-run`). If any required command is missing, **abort** with
+  `st-wait-until-green`, `st-finalize-repo`, `st-commit`,
+  `st-submit-pr`, `gh`, `git-cliff`, `st-docker-run`). If any
+  required command is missing, **abort** with
   setup instructions.
 - Verify `GH_TOKEN` is set in the environment. If not, **abort** with a
   message directing the user to set it.


### PR DESCRIPTION
# Pull Request

## Summary

- Use st-wait-until-green in pr-workflow, add to host tools

## Issue Linkage

- Ref #185

## Testing

- markdownlint

## Notes

- Adopts the new st-wait-until-green command (standard-tooling#397) in the pr-workflow skill, replacing the inline gh pr checks --watch --required invocation.

Changes:

- **skills/pr-workflow/SKILL.md**: replaced gh pr checks --watch --required with st-wait-until-green in the "Wait for CI green" section
- **skills/publish/SKILL.md**: added st-wait-until-green to the host commands list and the preflight required-commands check
- **hooks/scripts/lib/host-container-tools.sh**: added st-wait-until-green to HOST_TOOLS array