### PR TITLE
docs: add v2.0 skill rearchitecture spec and pushback review

### DIFF
--- a/docs/specs/v2-skill-rearchitecture.md
+++ b/docs/specs/v2-skill-rearchitecture.md
@@ -1,0 +1,177 @@
+# v2.0 Skill Rearchitecture — Architectural Review
+
+**Date:** 2026-04-29
+**Issue:** [#187](https://github.com/wphillipmoore/standard-tooling-plugin/issues/187)
+**Scope:** All six plugin skills reviewed against `superpowers:writing-skills` methodology
+
+## Context
+
+The plugin's six skills (`pr-workflow`, `publish`, `dependency-update`,
+`deprecation-triage`, `project-issue`, `summarize`) were developed through
+ad-hoc trial and error without the structured methodology defined in
+`superpowers:writing-skills`. This document captures the initial
+architectural review that identified systematic gaps and produced the
+prioritized recommendations in issue #187.
+
+## Skills Inventory
+
+| Skill | ~Words | Type | Summary |
+|---|---|---|---|
+| `publish` | 2,200+ | Workflow/technique | 7-phase release lifecycle |
+| `pr-workflow` | 1,500+ | Workflow/technique | PR submission through merge and cleanup |
+| `dependency-update` | 1,000+ | Workflow/technique | Repeatable dependency update process |
+| `project-issue` | 700+ | Workflow/technique | Guided GitHub issue creation |
+| `summarize` | 500 | Workflow/technique | Multi-mode structured summarization |
+| `deprecation-triage` | 400 | Workflow/technique | Deprecation warning triage and tracking |
+
+## Finding 1: Descriptions — Every Skill Violates the CSO Anti-Pattern
+
+The writing-skills guide explicitly warns that when a description summarizes
+the skill's workflow, Claude may follow the description instead of reading the
+full skill content.
+
+All six descriptions summarize workflow rather than describing triggering
+conditions:
+
+| Skill | Current Description | Problem |
+|---|---|---|
+| `pr-workflow` | "Submit a pull request, wait for CI to go green, and hand off to the user for review and merge." | Agent may follow this 3-step summary and skip the full skill — missing `Ref` vs `Fixes` policy, post-merge verification, explicit issue closure |
+| `publish` | "Drive the end-to-end publish workflow..." | Agent may wing it rather than following the 7-phase procedure |
+| `project-issue` | "Create a well-structured GitHub issue by collecting required attributes through guided questions." | Process summary, not trigger |
+| `dependency-update` | "Run the dependency update workflow with validation, failure handling, and anchor record requirements." | Process summary |
+| `deprecation-triage` | "Triage deprecation warnings into a consistent workflow..." | Process summary |
+| `summarize` | "Multi-mode summarization for decisions, operations, or stream-of-consciousness capture. Use when..." | Leads with process summary; the "Use when" is buried second |
+
+Descriptions should start with "Use when..." and describe only triggering
+conditions. Examples:
+
+- `pr-workflow`: "Use when a feature branch is ready for review and needs to be submitted, monitored through CI, and handed off for merge. Runs from inside the issue's worktree."
+- `publish`: "Use when cutting a release or deploying documentation, after all feature work for the version is merged to develop."
+- `deprecation-triage`: "Use when deprecation warnings surface in test output, logs, or dependency changelogs — whether detected by the PostToolUse hook or noticed manually."
+
+The `pr-workflow` case is the most dangerous. Its description is a three-step
+recipe. An agent under time pressure will follow "submit, wait, hand off" and
+skip the 275-line skill — missing the `Ref`-only linkage rule,
+`st-finalize-repo`, post-merge workflow verification, and explicit issue
+closure.
+
+## Finding 2: No Evidence of TDD Testing
+
+The writing-skills iron law: "No skill without a failing test first."
+
+None of the skills show artifacts of the RED-GREEN-REFACTOR cycle:
+
+- No rationalization tables — what excuses do agents use to skip steps?
+- No red flags lists — self-check signals that you're about to violate the skill
+- No common mistakes sections (except `publish`'s host-vs-container, which is the closest thing)
+
+This matters most for discipline-enforcing aspects. The `pr-workflow` skill has
+several critical policies ("don't auto-merge," "use Ref not Fixes," "close the
+issue explicitly") that agents routinely violate. Without pressure-tested
+rationalization counters, these read as rules an agent acknowledges and then
+quietly works around.
+
+For example, `pr-workflow` says "do not enable auto-merge" three times.
+Repetition suggests this has been a real problem — but the skill doesn't
+capture why agents do it or provide explicit counters.
+
+With TDD: run a subagent through a PR scenario without the skill, document that
+it auto-merges or skips issue closure or uses `Fixes #N`, then write the skill
+to address those specific failure modes with rationalization tables.
+
+## Finding 3: Token Efficiency — `publish` is a Runbook, Not a Skill
+
+| Skill | ~Words | Budget |
+|---|---|---|
+| `publish` | 2,200+ | <500 |
+| `pr-workflow` | 1,500+ | <500 |
+| `dependency-update` | 1,000+ | <500 |
+| `project-issue` | 700+ | <500 |
+| `summarize` | 500 | ~500 |
+| `deprecation-triage` | 400 | <500 |
+
+Options for `publish`:
+
+- **Decompose**: Phase 1-4 (release mechanics) as one skill, Phase 5 (already
+  a separate skill), Phase 6-7 (close and hand-off) as part of pr-workflow's
+  lifecycle
+- **Compress**: Move host-vs-container (referenced by 3 other skills) into its
+  own reference, cutting ~500 words
+- **Restructure**: Keep monolithic but move verbose sections to supporting files
+
+## Finding 4: Host-vs-Container is Load-Bearing Documentation in the Wrong Place
+
+The canonical host-vs-container split lives in `publish/SKILL.md` and is
+cross-referenced by three other skills. Problems:
+
+1. **Loading cost**: Any agent needing the rule must either load `publish`
+   (2,200 words) or already know it. Three skills say "see publish for the
+   canonical split."
+2. **Conceptual coupling**: The split is infrastructure knowledge, not
+   publish-specific. It belongs in a standalone reference.
+
+## Finding 5: Duplication Across Skills
+
+Several policies are explained in multiple places:
+
+- **`Ref` vs `Fixes` linkage**: Explained in detail in `pr-workflow` and
+  referenced in `publish`. Rationale given twice.
+- **GH_TOKEN check**: Four skills independently check for it.
+- **`st-finalize-repo` behavior**: Described in both `pr-workflow` and
+  `publish`.
+- **"Humans merge feature PRs" policy**: Stated in `pr-workflow` and restated
+  in `publish`.
+
+A shared policy reference or single canonical skill that others cite would
+reduce token cost and eliminate drift risk.
+
+## Finding 6: Missing "When NOT to Use" Guidance
+
+Only `publish` has an exclusion ("not applicable to application repositories").
+Others would benefit:
+
+- `pr-workflow`: Not for release-workflow PRs (those use `publish` directly).
+  Stated but buried, not in a "When to Use" block.
+- `dependency-update`: Not clear whether security hotfixes bypass the chore
+  branch convention.
+- `project-issue`: Not clear whether cross-repo project-level tracking issues
+  are in scope.
+
+## Finding 7: No Decision Flowcharts Where They'd Help
+
+None of the skills use flowcharts. Several have non-obvious decision points:
+
+- `deprecation-triage`: Branching decision tree (existing issue? code-only fix
+  possible? defer? suppress?)
+- `pr-workflow`: CI failure triage (fixable vs. not-fixable)
+- `publish`: Mode selection (library-release vs. docs-only) and Phase 3's
+  issue-linkage repair logic
+
+## Finding 8: Structural Homogeneity
+
+All six skills are operational workflows (technique type). The skill set is
+missing:
+
+- **Reference skills**: Host-vs-container split, commit/PR standards, worktree
+  convention
+- **Pattern skills**: "When to defer vs. fix now" (used by deprecation-triage
+  and dependency-update), "failure escalation" (used by publish, pr-workflow,
+  dependency-update)
+
+Extracting these would reduce workflow skill word counts and make shared
+judgment calls explicit.
+
+## Recommendations (Prioritized)
+
+1. **Rewrite all six descriptions** — start with "Use when...", triggering
+   conditions only, no workflow summaries
+2. **Pressure-test discipline-enforcing aspects** with subagent TDD scenarios;
+   add rationalization tables and red flags
+3. **Extract host-vs-container** into a standalone reference skill or doc
+4. **Consolidate duplicated policies** (Ref linkage, GH_TOKEN, finalize-repo,
+   merge policy) into shared references
+5. **Add decision flowcharts** to deprecation-triage and pr-workflow CI-failure
+   triage
+6. **Compress publish** — decompose or move verbose sections to supporting files
+7. **Add "Common Mistakes" and "When NOT to use"** sections, especially to
+   pr-workflow and publish

--- a/paad/pushback-reviews/2026-04-29-v2-skill-rearchitecture-pushback.md
+++ b/paad/pushback-reviews/2026-04-29-v2-skill-rearchitecture-pushback.md
@@ -1,0 +1,136 @@
+# Pushback Review: v2.0 Skill Rearchitecture
+
+**Date:** 2026-04-29
+**Spec:** [#187](https://github.com/wphillipmoore/standard-tooling-plugin/issues/187) and `docs/specs/v2-skill-rearchitecture.md`
+**Commit:** 1e999eb (HEAD of develop at review time)
+
+## Source Control Conflicts
+
+None — no conflicts with recent changes. Three recent commits validated the
+analysis rather than contradicting it:
+
+| Commit | Date | Relevance |
+|---|---|---|
+| `4787974` | Apr 28 | Strengthened issue-closure step because agents were skipping it — validates finding #2 |
+| `e04eec5` | Apr 29 | Added `block-agent-merge` PreToolUse hook — mechanically enforces no-auto-merge policy |
+| `50c060b` | Apr 29 | Added `st-wait-until-green` to pr-workflow and host tools list |
+
+## Issues Reviewed
+
+### [1] Token budget may not apply to on-demand workflow runbooks
+
+- **Category:** Feasibility
+- **Severity:** Serious
+- **Issue:** The spec adopts the writing-skills guide's <500 word budget as the
+  target for all skills. But that budget targets personal skills that load
+  frequently. Plugin workflow skills are on-demand — they load once per
+  invocation (e.g., `publish` loads once per release cycle). Compressing
+  `publish` to <500 words would require losing critical instructions or
+  splitting into multiple skills that agents must invoke in sequence.
+- **Resolution:** Combine two approaches: (1) Tiered budgets by loading
+  frequency — always-loaded <200 words, frequently-loaded <500 words, on-demand
+  workflow skills minimize redundancy but no hard cap. (2) Supporting files for
+  edge cases — SKILL.md contains decision logic and "when to read more"
+  pointers, supporting files stay out of context until triggered. Example:
+  `publish` keeps Phase 4's cross-repo docker verification in a supporting file
+  gated by "When publishing `standard-tooling`, read `docker-verification.md`."
+
+### [2] No distinction between hook-enforced and documentation-enforced policies
+
+- **Category:** Omission
+- **Severity:** Serious
+- **Issue:** The spec treats all discipline problems as documentation problems.
+  But hooks already mechanically enforce some policies (`block-agent-merge`
+  prevents `gh pr merge` on non-release PRs; `block-autoclose-linkage` prevents
+  `Fixes`/`Closes` keywords). The heredoc blocker is the proof case: prose
+  telling agents not to use heredocs has never been respected — the hook catches
+  it every time and agents self-correct. Documentation that duplicates hook
+  enforcement is ignored, unmaintainable, and adds context cost.
+- **Resolution:** Hook-enforced policies get no skill prose — delete existing
+  duplicates. The hook is the enforcement; the agent bumps into the gate, reads
+  the error message, and self-corrects. TDD pressure testing focuses exclusively
+  on judgment-dependent behaviors that have no hook backstop. Audit each
+  discipline rule and classify as hook-enforced or judgment-dependent.
+
+### [3] No testing maintenance or CI story
+
+- **Category:** Omission
+- **Severity:** Serious
+- **Issue:** The spec requires TDD pressure testing but doesn't address where
+  test scenarios live, how they're re-run, or how regressions are detected.
+  The thesis is "treat skills like code" — code without CI is just code that
+  used to work.
+- **Resolution:** Adopt whatever conventions the writing-skills guide
+  establishes for test artifact storage and format. Each v2.0 skill ships with
+  its pressure scenarios alongside it. CI automation for skill testing is in
+  scope but will be designed as the testing conventions take shape — not
+  specified upfront. This is greenfield: no existing conventions to preserve.
+  The plugin may need its own repository profile type (distinct from library,
+  tooling, documentation) since it publishes skills, not packages.
+
+### [4] Recommendation efforts vary from 30 minutes to weeks
+
+- **Category:** Scope imbalance
+- **Severity:** Moderate
+- **Issue:** The seven recommendations range from 1-2 hours (rewrite
+  descriptions) to 1-2+ weeks (TDD pressure testing). More importantly, the
+  writing-skills iron law says you can't edit a skill without testing it first
+  — so recommendations 1, 3, 4, 5, 6, and 7 all technically depend on
+  recommendation #2 (establishing the testing methodology).
+- **Resolution:** Reorder for implementation: testing methodology first. Pilot
+  on `deprecation-triage` (smallest, simplest skill). Then apply the
+  methodology to each remaining skill, giving each its full v2.0 treatment
+  (description, structure, compression, testing) in one pass rather than
+  sweeping one recommendation across all six skills. Build the machine that
+  builds the skills — the machinery is more important than the skills
+  themselves.
+
+### [5] No migration plan from v1 to v2
+
+- **Category:** Omission
+- **Severity:** Moderate
+- **Issue:** Six skills are currently deployed and consumed. The spec doesn't
+  address how to transition without breaking consuming repos mid-transition,
+  or what happens when v2 skills cross-reference v1 skills.
+- **Resolution:** Rename skills as part of v2.0 — new names give clean
+  coexistence. Old and new run in parallel during development. Cutover is a
+  manual decision after the new skill passes TDD tests and demonstrates parity.
+  The single-operator model allows this flexibility. No formal migration plan
+  needed.
+
+### [6] "Compress publish" has multiple conflicting options
+
+- **Category:** Ambiguity
+- **Severity:** Moderate
+- **Issue:** Recommendation #6 lists three options (decompose, compress,
+  restructure) without choosing. These have very different implications for
+  agent invocation patterns.
+- **Resolution:** Defer to the publish skill's sub-issue. Extracting
+  host-vs-container to a shared reference (recommendation #3) and removing
+  hook-enforced prose (Issue 2 resolution) will reduce publish's word count
+  significantly before any structural decision is needed. The right answer
+  depends on what's left after those reductions.
+
+### [7] Host-vs-container extraction destination unclear
+
+- **Category:** Ambiguity
+- **Severity:** Minor
+- **Issue:** Recommendation #3 says "standalone reference skill or doc" but
+  doesn't choose. A reference skill is discoverable but adds context cost.
+  A shared doc has zero discovery overhead but depends on referring skills.
+- **Resolution:** Shared doc, referenced by path from skills that need it. The
+  host/container split only matters during workflow execution — agents are
+  always inside a skill when they need it. May become unnecessary as tools
+  increasingly absorb the host/container decision-making. Revisit during the
+  relevant sub-issue.
+
+## Unresolved Issues
+
+None — all issues were addressed.
+
+## Summary
+
+- **Issues found:** 7
+- **Issues resolved:** 7
+- **Unresolved:** 0
+- **Spec status:** Ready for planning after resolutions are applied to the issue


### PR DESCRIPTION
# Pull Request

## Summary

- docs: add v2.0 skill rearchitecture spec and pushback review

## Issue Linkage

- Ref #187

## Testing

- markdownlint

## Notes

- Adds two design artifacts for the v2.0 skill rearchitecture effort:

- **Architectural review** (`docs/specs/v2-skill-rearchitecture.md`): Analysis of all six plugin skills against the `superpowers:writing-skills` methodology, identifying 8 findings across CSO descriptions, TDD testing, token efficiency, duplication, and structural gaps.

- **Pushback report** (`paad/pushback-reviews/2026-04-29-v2-skill-rearchitecture-pushback.md`): Critique of the recommendations with 7 resolved issues covering token budgets, hook-vs-documentation enforcement, testing conventions, implementation ordering, migration strategy, and deferred decisions.

These are planning artifacts only — no skill or code changes.