### PR TITLE
fix(hooks): remove uv from HOST_TOOLS to unblock st-docker-run -- uv run

### DIFF
--- a/hooks/scripts/lib/host-container-tools.sh
+++ b/hooks/scripts/lib/host-container-tools.sh
@@ -22,7 +22,6 @@ HOST_TOOLS=(
   gh
   git
   git-cliff
-  uv
 )
 
 # Container-only: language toolchain validators.


### PR DESCRIPTION
# Pull Request

## Summary

- Remove uv from HOST_TOOLS list — it is dual-use (host and container) and should not be denied when invoked after st-docker-run --

## Issue Linkage

- Ref #197

## Testing

- markdownlint

## Notes

- -