### PR TITLE
fix(hooks): block gh api equivalents of blocked gh subcommands (pr create, pr merge, pr review)

### DIFF
--- a/hooks/scripts/block-agent-merge.sh
+++ b/hooks/scripts/block-agent-merge.sh
@@ -20,8 +20,24 @@ fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
 
-if ! echo "$command" \
+is_merge_command=false
+
+if echo "$command" \
      | grep -qE '(^|[;&|]\s*)gh\s+pr\s+(merge(\s|$)|review\s+.*--approve)'; then
+  is_merge_command=true
+fi
+
+if echo "$command" | grep -qE 'gh\s+api\s+.*/pulls/[0-9]+/merge(\s|$)' \
+  && echo "$command" | grep -qiE '(-X\s+PUT|--method\s+PUT|-XPUT)'; then
+  is_merge_command=true
+fi
+
+if echo "$command" | grep -qE 'gh\s+api\s+.*/pulls/[0-9]+/reviews(\s|$)' \
+  && echo "$command" | grep -qiE '(-X\s+POST|--method\s+POST|-XPOST)'; then
+  is_merge_command=true
+fi
+
+if [ "$is_merge_command" = false ]; then
   exit 0
 fi
 

--- a/hooks/scripts/block-raw-gh-pr-create.sh
+++ b/hooks/scripts/block-raw-gh-pr-create.sh
@@ -20,14 +20,21 @@ fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
 
-if echo "$command" | grep -qE '(^|[;&|]\s*)gh\s+pr\s+create(\s|$)'; then
-  jq -n '{
+deny() {
+  jq -n --arg reason "$1" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
-      permissionDecisionReason: "Raw gh pr create is blocked. Use st-submit-pr instead. See docs/repository-standards.md for usage."
+      permissionDecisionReason: $reason
     }
   }'
+}
+
+if echo "$command" | grep -qE '(^|[;&|]\s*)gh\s+pr\s+create(\s|$)'; then
+  deny "Raw gh pr create is blocked. Use st-submit-pr instead. See docs/repository-standards.md for usage."
+elif echo "$command" | grep -qE 'gh\s+api\s+.*(/pulls)(\s|$)' \
+  && echo "$command" | grep -qiE '(-X\s+POST|--method\s+POST|-XPOST)'; then
+  deny "gh api POST to /pulls is equivalent to gh pr create and is blocked. Use st-submit-pr instead."
 else
   exit 0
 fi


### PR DESCRIPTION
# Pull Request

## Summary

- Block gh api POST/PUT equivalents of blocked gh subcommands in both block-raw-gh-pr-create and block-agent-merge hooks

## Issue Linkage

- Ref #216

## Testing

- markdownlint

## Notes

- -