### PR TITLE
chore(bootstrap): remove unnecessary tool-presence guard

### DIFF
--- a/agents/bootstrap.md
+++ b/agents/bootstrap.md
@@ -2,8 +2,8 @@
 name: bootstrap
 description: >-
   Session bootstrap agent. Use proactively at the start of every work session
-  to validate the repository profile, check branch state, verify the dev
-  container environment, and load context. Must run before any code changes.
+  to validate the repository profile, check branch state, and load context.
+  Must run before any code changes.
 tools: Read, Glob, Grep, Bash
 model: haiku
 maxTurns: 15
@@ -38,31 +38,7 @@ Run `git branch --show-current` and report the current branch.
 If the branch is `main` or `develop`, report:
 **WARNING: On protected branch. Create a feature branch before making changes.**
 
-## 3. Host Dispatcher (st-docker-run)
-
-Check if `st-docker-run` is available on PATH by running
-`command -v st-docker-run`.
-
-If found, report: **st-docker-run: available.**
-
-If not found, report (and include the link verbatim so the user can
-open it):
-
-**WARNING: st-docker-run not found on PATH. Validator dispatch
-(`st-validate-local`, dependency-update validation passes, and any
-container-routed lint/typecheck calls) will fail until it is installed.
-st-docker-run is the host-side dispatcher that runs language toolchain
-validators inside the dev container image; it is delivered by the
-standard-tooling Python package. See the Getting Started guide for host
-venv bootstrap and PATH setup:
-<https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/site/docs/getting-started.md>**
-
-Release-cycle tools (`st-commit`, `st-submit-pr`, `st-prepare-release`,
-`st-finalize-repo`, `st-merge-when-green`) run on the host and do not
-need st-docker-run — see [issue #96](https://github.com/wphillipmoore/standard-tooling-plugin/issues/96)
-for the host-vs-container split.
-
-## 4. Standards and Conventions
+## 3. Standards and Conventions
 
 Check if `../standards-and-conventions` exists as a directory.
 
@@ -71,7 +47,7 @@ If found, report: **Standards repo: resolved locally.**
 If not found, report:
 **WARNING: Standards repo not found locally. Using web source as fallback.**
 
-## 5. Git Hooks
+## 4. Git Hooks
 
 Run `git config core.hooksPath` and report the result.
 
@@ -90,7 +66,6 @@ Repository:    <repo name from directory>
 Profile:       <repository_type> | <branching_model> | <primary_language>
 Branch:        <current branch> [WARNING if protected]
 Validation:    <canonical_local_validation_command or "not configured">
-st-docker-run: <available or "NOT FOUND">
 Standards:     <local or web fallback>
 Git hooks:     <hooks path or "NOT CONFIGURED">
 =========================


### PR DESCRIPTION
## Summary

Audited all plugin hooks, scripts, agents, and skills for PATH manipulation
and tool-presence guards per the principle: if a tool should be present, just
call it and let it fail hard — don't second-guess at runtime.

## Audit findings

### Removed: `command -v st-docker-run` (bootstrap agent)

The bootstrap agent's Section 3 checked for `st-docker-run` on PATH and
emitted a long warning with a Getting Started link if missing. This is
defensive scaffolding — `st-docker-run` is delivered by the standard-tooling
package and should be assumed present. If it isn't, the first actual
invocation produces a clear `command not found` error.

Follows the same approach as #226 which removed the "Locating standard-tooling
host commands" section from the publish skill.

### Retained: legitimate patterns

The remaining `2>/dev/null` and fallback patterns in hook scripts are **not**
tool-presence guards — they are architectural gating and edge-case handling:

- **`block-protected-branch-work.sh`** — `git rev-parse 2>/dev/null` handles
  the case where the hook runs outside a git repo (line 73: "don't block —
  something else will fail or this was a non-repo commit")
- **`managed-repo-check.sh`** — file-existence checks for opt-in marker files
  (`repository-standards.md`, `st-config.yaml`); architectural gating, not
  tool detection
- **`block-agent-merge.sh`** — captures stderr from `st-check-pr-merge` for
  user-facing error messages; explicit error handling, not silent swallowing

### Not found

- No `shutil.which()` calls anywhere
- No raw `which` command invocations
- No PATH manipulation (`PATH=`, `export PATH`)
- No try/catch patterns that silently swallow missing-tool errors

## Acceptance criteria

- [x] Audit all plugin hooks and scripts for PATH manipulation and
      tool-presence guards
- [x] Document findings — which guards are legitimate vs defensive scaffolding
- [x] Remove or simplify unnecessary guards
- [x] Ensure failures are loud and actionable, not silent

Ref #218
