### PR TITLE
fix: remove st-validate-local from HOST_TOOLS

### DIFF
--- a/hooks/scripts/lib/host-container-tools.sh
+++ b/hooks/scripts/lib/host-container-tools.sh
@@ -16,7 +16,6 @@ HOST_TOOLS=(
   st-finalize-repo
   st-merge-when-green
   st-wait-until-green
-  st-validate-local
   st-docker-run
   st-ensure-label
   gh


### PR DESCRIPTION
# Pull Request

## Summary

- st-validate-local must run inside Docker via st-docker-run; it was incorrectly listed as a host-only tool, causing the enforce-host-container-split hook to deny the correct invocation.

## Issue Linkage

- Ref #235

## Testing

- markdownlint

## Notes

- -