### PR TITLE
Replace stale config file references with standard-tooling.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,9 @@ Sourced from the official Claude Code documentation:
 
 PreToolUse, PostToolUse, and Stop hooks that enforce guardrails
 mechanically. Every hook below **except `block-heredoc`** is
-gated on a managed-repo check: a repo must contain either
-`docs/repository-standards.md`, `st-config.toml`, or
-`st-config.yaml` at its root for the hook to fire. In repos
-without any marker, the gated hooks
+gated on a managed-repo check: a repo must contain
+`standard-tooling.toml` at its root for the hook to fire. In repos
+without this marker, the gated hooks
 short-circuit to a no-op so the plugin doesn't interfere with
 ad-hoc git work in unrelated repositories. See the
 [hooks reference](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/docs/site/docs/hooks/index.md#managed-repo-gating)

--- a/agents/bootstrap.md
+++ b/agents/bootstrap.md
@@ -20,9 +20,9 @@ report at the end. Do NOT make any changes to the repository.
 
 ## 1. Repository Profile
 
-Read `docs/repository-standards.md` in the current working directory.
+Read `standard-tooling.toml` in the current working directory.
 
-If it exists, extract and report:
+If it exists, extract and report from the `[project]` table:
 
 - `repository_type`
 - `branching_model`

--- a/docs/site/docs/agents/index.md
+++ b/docs/site/docs/agents/index.md
@@ -14,7 +14,7 @@ code changes are made.
 
 ### Checks Performed
 
-1. **Repository Profile** — reads `docs/repository-standards.md` and extracts
+1. **Repository Profile** — reads `standard-tooling.toml` and extracts
    `repository_type`, `branching_model`, `primary_language`, and
    `canonical_local_validation_command`
 

--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -19,18 +19,13 @@ to achieve the intent correctly when the hook blocks you.
 ## Managed-repo gating
 
 Every hook below **except `block-heredoc`** is gated on a
-managed-repo check. A repo is "managed" when any of these marker
-files exists at the repo root:
+managed-repo check. A repo is "managed" when `standard-tooling.toml`
+exists at the repo root.
 
-- `docs/repository-standards.md` — the existing per-repo config
-- `st-config.toml` — the single-file config
-- `st-config.yaml` — legacy variant (both formats accepted during
-  migration)
-
-When no marker is present, the gated hooks short-circuit to a
+When the marker is not present, the gated hooks short-circuit to a
 no-op so the plugin doesn't interfere with ad-hoc git work in
 unrelated repositories. Detection is a pure-shell walk up from the
-bash session's CWD looking for any marker, terminating at a
+bash session's CWD looking for the marker, terminating at a
 `.git` boundary or the filesystem root. No `git` subprocess; the
 gate's overhead is a handful of `stat()` calls.
 
@@ -50,7 +45,7 @@ pipe-chained equivalents).
 
 **Why.** `st-commit` constructs standards-compliant conventional
 commit messages with the co-author trailer resolved from
-`docs/repository-standards.md`. Hand-written `git commit -m`
+`standard-tooling.toml`. Hand-written `git commit -m`
 invocations drift from the commit-message standard over time; raw
 commits also bypass the co-author resolution entirely.
 

--- a/docs/specs/block-agent-merge.md
+++ b/docs/specs/block-agent-merge.md
@@ -229,7 +229,7 @@ extracts and forwards the `--repo` argument to the API call.
 3. **Allow case:** Input containing `gh pr merge <url>` where
    `st-check-pr-merge` returns 0. Expect allow (exit 0).
 4. **Non-managed repo:** Input with a cwd that has no
-   `docs/repository-standards.md`. Expect allow (exit 0).
+   `standard-tooling.toml`. Expect allow (exit 0).
 5. **No match:** Input containing `gh issue list`. Expect allow
    (exit 0).
 6. **gh pr review --approve block:** Input containing

--- a/docs/standards-and-conventions.md
+++ b/docs/standards-and-conventions.md
@@ -36,5 +36,5 @@ Conventions repository:
 
 ## Project-specific overlay
 
-Project-specific content lives in `docs/repository-standards.md` and is
+Project-specific content lives in `standard-tooling.toml` and is
 included from `AGENTS.md` only.

--- a/hooks/scripts/block-agent-merge.sh
+++ b/hooks/scripts/block-agent-merge.sh
@@ -4,7 +4,7 @@
 # Delegates branch verification to st-check-pr-merge.
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
-# either docs/repository-standards.md or st-config.yaml.
+# standard-tooling.toml.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/hooks/scripts/block-associative-arrays.sh
+++ b/hooks/scripts/block-associative-arrays.sh
@@ -4,8 +4,7 @@
 # macOS ships bash 3.2 (GPLv2) and will not upgrade to GPLv3 versions.
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
-# either docs/repository-standards.md or st-config.yaml. See
-# hooks/scripts/lib/managed-repo-check.sh.
+# standard-tooling.toml. See hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/hooks/scripts/block-autoclose-linkage.sh
+++ b/hooks/scripts/block-autoclose-linkage.sh
@@ -4,7 +4,7 @@
 # (Fixes, Closes, Resolves). Use --linkage Ref instead.
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
-# either docs/repository-standards.md or st-config.yaml.
+# standard-tooling.toml.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/hooks/scripts/block-protected-branch-work.sh
+++ b/hooks/scripts/block-protected-branch-work.sh
@@ -17,8 +17,7 @@
 # for the adopted-convention rules.
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
-# either docs/repository-standards.md or st-config.yaml. See
-# hooks/scripts/lib/managed-repo-check.sh.
+# standard-tooling.toml. See hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
 input=$(cat)

--- a/hooks/scripts/block-raw-gh-pr-create.sh
+++ b/hooks/scripts/block-raw-gh-pr-create.sh
@@ -31,7 +31,7 @@ deny() {
 }
 
 if echo "$command" | grep -qE '(^|[;&|]\s*)gh\s+pr\s+create(\s|$)'; then
-  deny "Raw gh pr create is blocked. Use st-submit-pr instead. See docs/repository-standards.md for usage."
+  deny "Raw gh pr create is blocked. Use st-submit-pr instead. See standard-tooling.toml for usage."
 elif echo "$command" | grep -qE 'gh\s+api\s+.*(/pulls)(\s|$)' \
   && echo "$command" | grep -qiE '(-X\s+POST|--method\s+POST|-XPOST)'; then
   deny "gh api POST to /pulls is equivalent to gh pr create and is blocked. Use st-submit-pr instead."

--- a/hooks/scripts/block-raw-gh-pr-create.sh
+++ b/hooks/scripts/block-raw-gh-pr-create.sh
@@ -3,8 +3,7 @@
 # Blocks raw 'gh pr create' commands. Use st-submit-pr instead.
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
-# either docs/repository-standards.md or st-config.yaml. See
-# hooks/scripts/lib/managed-repo-check.sh.
+# standard-tooling.toml. See hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/hooks/scripts/block-raw-git-commit.sh
+++ b/hooks/scripts/block-raw-git-commit.sh
@@ -3,8 +3,7 @@
 # Blocks raw 'git commit' commands. Use st-commit instead.
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
-# either docs/repository-standards.md or st-config.yaml. See
-# hooks/scripts/lib/managed-repo-check.sh.
+# standard-tooling.toml. See hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/hooks/scripts/block-raw-git-commit.sh
+++ b/hooks/scripts/block-raw-git-commit.sh
@@ -27,7 +27,7 @@ if echo "$command" | grep -qE '(^|[;&|]\s*)git\s+commit(\s|$)'; then
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
-      permissionDecisionReason: "Raw git commit is blocked. Use st-commit instead. See docs/repository-standards.md for usage."
+      permissionDecisionReason: "Raw git commit is blocked. Use st-commit instead. See standard-tooling.toml for usage."
     }
   }'
 else

--- a/hooks/scripts/detect-deprecation-warnings.sh
+++ b/hooks/scripts/detect-deprecation-warnings.sh
@@ -4,8 +4,7 @@
 # reminds Claude to triage them using the deprecation-triage skill.
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
-# either docs/repository-standards.md or st-config.yaml. See
-# hooks/scripts/lib/managed-repo-check.sh.
+# standard-tooling.toml. See hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
 input=$(cat)

--- a/hooks/scripts/enforce-host-container-split.sh
+++ b/hooks/scripts/enforce-host-container-split.sh
@@ -6,7 +6,7 @@
 # - WARN: bare-invoking a container-only tool without st-docker-run --
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
-# either docs/repository-standards.md or st-config.yaml.
+# standard-tooling.toml.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/hooks/scripts/lib/managed-repo-check.sh
+++ b/hooks/scripts/lib/managed-repo-check.sh
@@ -2,14 +2,11 @@
 # managed-repo-check.sh — shared helper for plugin enforcement hooks.
 #
 # A "managed" repo is one configured to use standard-tooling. The signal
-# is the presence of either of two marker files at the repo root:
+# is the presence of the marker file at the repo root:
 #
-#   docs/repository-standards.md   — the existing per-repo config
-#   st-config.toml                 — the single-file config
-#   st-config.yaml                 — legacy variant (both formats
-#                                    accepted during migration)
+#   standard-tooling.toml
 #
-# When neither marker is present, the plugin's enforcement hooks
+# When the marker is not present, the plugin's enforcement hooks
 # short-circuit to a no-op so the plugin does not interfere with
 # ad-hoc git work in repositories that have not opted in.
 #
@@ -24,8 +21,8 @@
 
 # is_managed_repo <starting-dir>
 #
-# Walks up from <starting-dir> looking for either marker file. Returns
-# 0 (true) if a marker is found, 1 (false) otherwise. Termination
+# Walks up from <starting-dir> looking for the marker file. Returns
+# 0 (true) if the marker is found, 1 (false) otherwise. Termination
 # conditions:
 #   1. A marker file is found    → return 0 (managed)
 #   2. A `.git` boundary is found (file or directory — both are valid
@@ -35,7 +32,7 @@
 #   3. The walk reaches `/` or an empty path → return 1 (not managed).
 #
 # Implementation note: pure shell. No subprocess spawns (no `git`,
-# no `dirname`, no `realpath`). Each iteration is three `[ -f ]`
+# no `dirname`, no `realpath`). Each iteration is one `[ -f ]`
 # and one `[ -e ]` — sub-millisecond per call.
 is_managed_repo() {
 	local dir="${1:-$PWD}"
@@ -47,7 +44,7 @@ is_managed_repo() {
 	esac
 
 	while [ "$dir" != "/" ] && [ -n "$dir" ]; do
-		if [ -f "$dir/docs/repository-standards.md" ] || [ -f "$dir/st-config.toml" ] || [ -f "$dir/st-config.yaml" ]; then
+		if [ -f "$dir/standard-tooling.toml" ]; then
 			return 0
 		fi
 		if [ -e "$dir/.git" ]; then

--- a/hooks/scripts/remind-finalize.sh
+++ b/hooks/scripts/remind-finalize.sh
@@ -3,8 +3,7 @@
 # After st-submit-pr runs, reminds Claude to finalize after the PR merges.
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
-# either docs/repository-standards.md or st-config.yaml. See
-# hooks/scripts/lib/managed-repo-check.sh.
+# standard-tooling.toml. See hooks/scripts/lib/managed-repo-check.sh.
 set -euo pipefail
 
 input=$(cat)

--- a/skills/dependency-update/SKILL.md
+++ b/skills/dependency-update/SKILL.md
@@ -53,7 +53,7 @@ for the canonical split and rationale
 1. Confirm you are on a `chore/` branch off `develop` (e.g.,
    `chore/next-cycle-deps-<version>` for post-publish, or
    `chore/dep-update-<date>` for standalone).
-2. Read `docs/repository-standards.md` to identify:
+2. Read `standard-tooling.toml` to identify:
    - `repository_type` — determines which categories apply.
    - The canonical validation command.
 3. Verify `GH_TOKEN` is set.

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -203,9 +203,9 @@ not force-remove sibling worktrees.
 ### Verify post-merge async workflows
 
 A PR is not "done" until every async workflow triggered by the
-merge has succeeded. The repository's `docs/repository-standards.md`
-lists the post-merge async workflows in its "Post-merge async
-workflows" section. Verify each one.
+merge has succeeded. The repository's `standard-tooling.toml`
+lists the post-merge async workflows in its `[workflows.post-merge]`
+section. Verify each one.
 
 For each workflow in the table:
 

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -116,7 +116,7 @@ st-docker-run -- markdownlint .
 
 ## Preflight
 
-- Read `docs/repository-standards.md` and locate the repository profile section.
+- Read `standard-tooling.toml` and locate the `[project]` section.
 - Read `repository_type` from the profile.
 - If the type is `library` or `tooling`, follow **library-release mode**.
 - If the type is `documentation`, follow **docs-only mode**.


### PR DESCRIPTION
# Pull Request

## Summary

- Replace stale config file references with standard-tooling.toml

## Issue Linkage

- Ref #228

## Testing

- markdownlint

## Notes

- ## Summary

Replaces all references to the three legacy config file names
(`docs/repository-standards.md`, `st-config.toml`, `st-config.yaml`)
with `standard-tooling.toml` across hooks, skills, agents, and docs.

### Changes by category

**Functional fix (highest priority):**
- `managed-repo-check.sh` — detection logic now checks only for
  `standard-tooling.toml` (was a three-way OR)

**User-facing error messages:**
- `block-raw-git-commit.sh`, `block-raw-gh-pr-create.sh` — denial
  messages now reference `standard-tooling.toml`

**Comment headers:**
- All nine gated hook scripts updated from "either
  docs/repository-standards.md or st-config.yaml" to
  "standard-tooling.toml"

**Skill and agent instructions:**
- `publish`, `dependency-update`, `pr-workflow` skills and
  `bootstrap` agent now direct agents to read `standard-tooling.toml`

**Documentation:**
- README, hooks index, agents index, standards-and-conventions,
  block-agent-merge spec all updated

### Out of scope

Historical release notes (`releases/`, `CHANGELOG.md`) are left
as-is — accurate records of what was true at the time.