### PR TITLE
chore(ci): upgrade to standard-actions v1.5 for config enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,43 +5,33 @@ on:
   workflow_call:
     inputs:
       run-security:
-        type: string
-        default: 'true'
-      run-release-gates:
-        type: string
-        default: 'true'
+        type: boolean
+        default: true
+      run-release:
+        type: boolean
+        default: true
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
 
   # ---------------------------------------------------------------------------
-  # Quality: shellcheck, mkdocs-build
+  # Quality
   # ---------------------------------------------------------------------------
 
-  shellcheck:
-    name: "ci: shellcheck"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run shellcheck
-        run: |
-          files=$(find hooks/scripts -type f -name '*.sh' | sort)
-          if [ -n "$files" ]; then
-            echo "$files" | xargs shellcheck
-          else
-            echo "No shell scripts found."
-          fi
+  quality:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-quality.yml@v1.5
+    with:
+      language: shell
+      versions: '["latest"]'
 
   mkdocs-build:
-    name: "ci: mkdocs-build"
+    name: "quality / mkdocs-build"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -60,28 +50,27 @@ jobs:
         working-directory: docs/site
 
   # ---------------------------------------------------------------------------
-  # Security and standards (shared reusable workflow)
+  # Security and standards
   # ---------------------------------------------------------------------------
 
-  security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4
+  security:
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
     with:
-      language: bash
-      semgrep-language: ci
-      run-codeql: 'false'
-      run-standards: ${{ inputs.run-release-gates || 'true' }}
-      run-security: ${{ inputs.run-security || 'true' }}
+      language: shell
+      run-codeql: false
+      run-standards: ${{ inputs.run-release || true }}
+      run-security: ${{ inputs.run-security || true }}
     permissions:
       contents: read
       security-events: write
 
   # ---------------------------------------------------------------------------
-  # Release gates (PR only)
+  # Release
   # ---------------------------------------------------------------------------
 
-  release-gates:
-    name: "release: gates"
-    if: ${{ inputs.run-release-gates != 'false' }}
+  release:
+    name: "release / version-bump"
+    if: ${{ inputs.run-release != false }}
     runs-on: ubuntu-latest
     steps:
       - name: Skip on non-PR events
@@ -100,7 +89,7 @@ jobs:
 
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.4
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.5
         with:
           head-version-command: jq -r '.version' .claude-plugin/plugin.json
           main-version-command: git show origin/main:.claude-plugin/plugin.json | jq -r '.version'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,6 @@ jobs:
           fetch-depth: 0
 
       - name: Deploy docs
-        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.4
+        uses: wphillipmoore/standard-actions/actions/docs-deploy@v1.5
         with:
           version-command: jq -r '.version | split(".") | .[0:2] | join(".")' .claude-plugin/plugin.json

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Tag and release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.4
+        uses: wphillipmoore/standard-actions/actions/publish/tag-and-release@v1.5
         with:
           version: ${{ steps.version.outputs.version }}
           release-title: standard-tooling-plugin
@@ -64,7 +64,7 @@ jobs:
 
       - name: Version bump PR
         if: steps.tag_check.outputs.exists == 'false'
-        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.4
+        uses: wphillipmoore/standard-actions/actions/publish/version-bump-pr@v1.5
         with:
           current-version: ${{ steps.version.outputs.version }}
           version-file: .claude-plugin/plugin.json

--- a/standard-tooling.toml
+++ b/standard-tooling.toml
@@ -18,5 +18,9 @@ does not reliably pick up hook changes. To fully apply the update, \
 restart any active Claude Code sessions.
 """
 
+[ci]
+versions = ["latest"]
+integration-tests = false
+
 [dependencies]
 standard-tooling = "v1.4"


### PR DESCRIPTION
# Pull Request

## Summary

- Upgrade all workflow references from standard-actions v1.4 to v1.5, restructure CI to use v1.5 reusable workflows with new check naming convention, and add [ci] section to standard-tooling.toml for derivation engine support. Issue is in wphillipmoore/standard-tooling.

## Issue Linkage

- Ref #173

## Testing

- markdownlint

## Notes

- -