### PR TITLE
feat: add end-of-run operational summary to pr-workflow and publish skills

### DIFF
--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -15,6 +15,7 @@ description: Submit a pull request, wait for CI to go green, and hand off to the
 - [Hand-off to the user](#hand-off-to-the-user)
 - [After the merge](#after-the-merge)
 - [Close the issue](#close-the-issue)
+- [Operational summary](#operational-summary)
 - [Resources](#resources)
 
 ## Overview
@@ -262,6 +263,49 @@ do not close the issue. Only close when the last PR in the
 series has been finalized.
 
 This concludes the work cycle.
+
+## Operational summary
+
+After the work cycle concludes — whether at hand-off, after issue
+closure, or after surfacing an unrecoverable failure — produce a
+concise operational report covering every step of the workflow.
+
+The agent is expected to encounter CI failures and fix them
+autonomously during the CI-gate loop. These fixes happen without
+human review and some may be inappropriate — a workaround that
+silences a lint error, a test modification that masks a real
+regression, a dependency pin that papers over a conflict. The
+operational summary makes all of this visible so the user can
+catch problems during PR review rather than discovering them in
+production.
+
+Structure the report as a step-by-step checklist:
+
+1. **Preflight** — pass/fail, any missing tools or setup issues.
+2. **Pre-submission validation** — pass on first run, or list each
+   failure encountered and the fix applied.
+3. **Submission** — pass/fail.
+4. **CI gate** — number of fix cycles. For each cycle: the failing
+   check, the root cause, and the fix applied. If the final state
+   is not green, note what was surfaced to the user and why.
+5. **Hand-off** — whether CI was green at hand-off.
+6. **Finalization** — pass/fail, any non-fatal errors from
+   `st-finalize-repo`.
+7. **Post-merge workflows** — pass/fail for each workflow checked.
+8. **Issue closure** — completed or skipped (with reason if
+   skipped).
+
+For each step that required a fix or workaround, classify it:
+
+- **Mechanical** — formatting, lint, import ordering. Low risk.
+- **Substantive** — logic change, test modification, dependency
+  adjustment, configuration change. Requires review attention.
+
+The CI gate section is the most critical part of this report.
+This is where the agent operates autonomously and where
+inappropriate fixes are most likely to go unnoticed. Be explicit
+about every commit made during the fix loop — what changed, why,
+and whether the change was mechanical or substantive.
 
 ## Resources
 

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -24,6 +24,7 @@ description: Drive the end-to-end publish workflow for library, tooling, and doc
   - [Phase 1 — Confirm deployment](#phase-1--confirm-deployment)
   - [Phase 2 — Toolchain dependency updates](#phase-2--toolchain-dependency-updates)
 - [Dependency update categories](#dependency-update-categories)
+- [Operational summary](#operational-summary)
 - [Resources](#resources)
 
 ## Overview
@@ -442,6 +443,53 @@ regenerate derived artifacts, run full validation. Failures follow the
 - Linters, formatters, and type checkers (ruff, mypy, ty, markdownlint-cli).
 - Test frameworks and coverage tools (pytest, coverage).
 - Build tools (hatch, setuptools, uv).
+
+## Operational summary
+
+After the final phase completes (Phase 7 for library-release,
+Phase 2 for docs-only), or after the workflow stops due to a
+failure, produce a concise operational report covering every phase.
+
+The publish workflow's failure policy is "stop and report — never
+stop and fix." The operational summary confirms either that every
+phase succeeded cleanly or documents exactly where the workflow
+stopped and why. A clean publish should produce an all-green
+report; any deviation is a signal worth investigating.
+
+**Library-release mode:**
+
+1. **Preflight** — pass/fail, version captured.
+2. **Version override** — applied/skipped, target version if
+   applied.
+3. **Phase 1 — Prepare release** — pass/fail, tracking issue and
+   PR URL.
+4. **Phase 2 — Merge release PR** — pass/fail, merge commit.
+5. **Phase 3 — Merge bump PR** — pass/fail, whether issue-linkage
+   repair was needed.
+6. **Phase 4 — Confirm publish** — pass/fail for each workflow
+   (`publish.yml`, `docs.yml`), artifacts confirmed.
+7. **Phase 5 — Dependency updates** — pass/fail, categories
+   updated.
+8. **Phase 6 — Close tracking issue** — pass/fail, finalization
+   outcome.
+9. **Phase 7 — Consumer-refresh hand-off** — displayed/not
+   displayed.
+
+**Docs-only mode:**
+
+1. **Preflight** — pass/fail.
+2. **Phase 1 — Confirm deployment** — pass/fail.
+3. **Phase 2 — Toolchain dependency updates** — pass/fail,
+   finalization outcome.
+
+If the workflow stopped at any phase due to a failure, mark all
+subsequent phases as "not reached" and note the failure that
+caused the stop. The failure should already be documented on the
+tracking issue per the failure-handling procedure; the summary
+collects it into a single view.
+
+This report is the final output of the skill — produce it after
+all other work is complete (or after the workflow has stopped).
 
 ## Resources
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add end-of-run operational summary to pr-workflow and publish skills

## Issue Linkage

- Ref #247

## Testing

- markdownlint

## Notes

- Add an Operational Summary section to both the pr-workflow and publish skills.
In pr-workflow, the summary covers every step with special emphasis on the CI-gate fix loop — classifying each fix as mechanical or substantive so the reviewer can spot inappropriate workarounds.
In publish, the summary confirms all-phases-green or documents exactly where the workflow stopped, reinforcing the stop-and-report failure policy.