### PR TITLE
Add container-suffix to ci-quality workflow call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       language: shell
       versions: '["latest"]'
+      container-suffix: base
 
   mkdocs-build:
     name: "quality / mkdocs-build"


### PR DESCRIPTION
# Pull Request

## Summary

- Pass container-suffix: base to ci-quality since language is shell

## Issue Linkage

- Ref #252

## Testing

- markdownlint

## Notes

- The quality job calls ci-quality.yml from standard-actions v1.5 with language: shell but did not pass container-suffix: base. Without it, the lint and typecheck jobs would try to pull ghcr.io/wphillipmoore/dev-shell:latest which does not exist.