### PR TITLE
chore: decommission st-validate-local remnants

### DIFF
--- a/docs/development/skills-architecture.md
+++ b/docs/development/skills-architecture.md
@@ -36,7 +36,7 @@ agent or human picks up an issue.
 | Phase | Purpose | Hand-off |
 |---|---|---|
 | B1. Set up workspace | Resolve issue → branch name → **worktree** on a feature branch tied to the issue. One worktree per issue, never on `develop`/`main`. | → B2 |
-| B2. Develop | Edit, validate (`st-validate-local`), iterate, commit (`st-commit`). Multiple commits OK. | → B3 |
+| B2. Develop | Edit, validate (`st-docker-run -- uv run st-validate`), iterate, commit (`st-commit`). Multiple commits OK. | → B3 |
 | B3. Submit | Push, create PR via `st-submit-pr`, link issue with `Fixes`/`Closes`/`Resolves`/`Ref`. Wait for CI green. **Human reviews and merges feature/bugfix PRs.** | → B4 (after merge) |
 | B4. Finalize | `st-finalize-repo`: pull develop, delete merged feature branch, prune worktrees and remotes. | → exit work cycle |
 
@@ -228,7 +228,7 @@ anchored records). Mostly references external docs.
 
 **What's changed since.** The host-vs-container split affects
 which validators the workflow invokes. The skill predates
-`st-validate-local` being canonical.
+`st-validate` being canonical.
 
 **Slash-command runnability.** No. The skill is too thin to drive a
 session — it doesn't say *how* to update Python deps vs. CI action
@@ -241,7 +241,7 @@ concrete commands.
 encodes concrete commands per dependency category (library deps
 via `uv lock --upgrade`, CI action pins, runtime versions, doc
 toolchain, linters, test frameworks, build tools). Validation
-uses `st-validate-local`. Failure handling structured around the
+uses `st-validate`. Failure handling structured around the
 anchored dependency record workflow. Anchor review is a
 first-class section: every sweep checks existing anchors for
 exit-criteria resolution. Submission hands off explicitly to
@@ -523,7 +523,7 @@ referenced the skill; now the skill references the hook.
 rewrite. The skill now encodes concrete commands per dependency
 category (Python direct deps and lockfile via `uv lock`, CI
 action pins, runtime version pins, doc toolchain, linters, test
-frameworks, build tools). Validation uses `st-validate-local` as
+frameworks, build tools). Validation uses `st-validate` as
 the canonical step. Failure handling is structured around the
 anchored dependency record workflow with explicit "never silently
 pin" policy. Submission hands off to `pr-workflow`. Added anchor

--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -140,9 +140,9 @@ split from
 - **Warns** (via `additionalContext`, not deny) when a
   container-only tool is invoked directly — whether bare
   (e.g., `ruff check .`) or wrapped in `st-docker-run --`.
-  Both bypass the `scripts/dev/*.sh` abstraction layer that
-  each repo maintains. The correct entry point is
-  `st-validate-local`, which delegates to those scripts.
+  Both bypass the canonical validation entry point. The correct
+  command is `st-docker-run -- uv run st-validate`, which handles
+  all tool routing internally.
 
 The canonical tool lists live in
 `hooks/scripts/lib/host-container-tools.sh` so the same source of
@@ -152,15 +152,15 @@ truth powers both the hook and any future docs/lint.
 wrapping host tools in the container — was caused by documentation
 being the only enforcement mechanism. Issue
 [#168](https://github.com/wphillipmoore/standard-tooling-plugin/issues/168)
-extended this to also catch agents bypassing the `scripts/dev`
-abstraction by calling linters directly (even correctly wrapped in
-`st-docker-run`). The agent should never invoke individual
-linters — `st-validate-local` handles tool routing internally.
+extended this to also catch agents bypassing the canonical
+validation entry point by calling linters directly (even correctly
+wrapped in `st-docker-run`). The agent should never invoke
+individual linters — `st-validate` handles tool routing internally.
 
 **Alternative.** For denied commands: invoke the host tool
 directly (drop the `st-docker-run --` prefix). For warned
-commands: use `st-validate-local` instead of invoking individual
-linters. See the
+commands: use `st-docker-run -- uv run st-validate` instead of invoking
+individual linters. See the
 [`publish` skill's host-vs-container section](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/skills/publish/SKILL.md#host-vs-container-commands)
 for the canonical split and rationale.
 
@@ -264,13 +264,13 @@ work — five container starts for a single Python edit (`ruff check
 --fix`, `ruff format`, `ruff check`, `mypy`, `ty check`). Across a
 session with dozens of edits, that's minutes of wall-clock overhead
 per session, every session. The same checks already run in two
-cheaper places: `st-validate-local` covers them in a single
+cheaper places: `st-validate` covers them in a single
 container start before PR submission, and CI re-runs them on every
 PR. The per-edit layer was the third copy with the worst
 cost-per-value ratio.
 
 **What replaces it.** Nothing per-edit. Validation runs at PR time
-via [`st-validate-local`](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/site/docs/reference/dev/validate-local.md),
+via [`st-validate`](https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/site/docs/reference/dev/validate.md),
 which is the documented "only validation command" per every
 consuming repo's CLAUDE.md. The
 [`block-raw-git-commit`](#block-raw-git-commit) PreToolUse hook

--- a/docs/site/docs/skills/index.md
+++ b/docs/site/docs/skills/index.md
@@ -77,7 +77,7 @@ maintenance.
 ([#114](https://github.com/wphillipmoore/standard-tooling-plugin/issues/114))
 with concrete per-category commands (Python deps via `uv lock`,
 CI action pins, runtime versions, doc toolchain, linters, build
-tools), `st-validate-local` as the canonical validation step,
+tools), `st-validate` as the canonical validation step,
 structured failure handling via anchored dependency records, and
 anchor review as a first-class section.
 

--- a/hooks/scripts/enforce-host-container-split.sh
+++ b/hooks/scripts/enforce-host-container-split.sh
@@ -44,7 +44,7 @@ for tool in "${CONTAINER_TOOLS[@]}"; do
     jq -n --arg tool "$tool" '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        additionalContext: ("WARNING: \($tool) should not be invoked directly. Use st-validate-local for validation — it delegates to scripts/dev/*.sh which handle tool routing internally. See issue #168: https://github.com/wphillipmoore/standard-tooling-plugin/issues/168")
+        additionalContext: ("WARNING: \($tool) should not be invoked directly. Use st-docker-run -- uv run st-validate for validation — it handles tool routing internally. See issue #168: https://github.com/wphillipmoore/standard-tooling-plugin/issues/168")
       }
     }'
     exit 0

--- a/skills/dependency-update/SKILL.md
+++ b/skills/dependency-update/SKILL.md
@@ -40,10 +40,10 @@ with exit criteria — never silently pinned.
 
 Most commands in this skill are **host commands** — invoke them directly
 without `st-docker-run` wrapping. This includes `uv`, `gh`, `st-commit`,
-`st-validate-local`, and all `st-*` workflow tools.
+`st-validate`, and all `st-*` workflow tools.
 
-The only container-dispatched work happens inside `st-validate-local`,
-which handles that routing internally. See the
+Validation runs via `st-docker-run -- uv run st-validate`, which
+dispatches all checks inside the container. See the
 [`publish` skill's host-vs-container section](../publish/SKILL.md#host-vs-container-commands)
 for the canonical split and rationale
 ([#96](https://github.com/wphillipmoore/standard-tooling-plugin/issues/96)).
@@ -159,12 +159,11 @@ records:
 After all updates in a category (or after all categories if batching):
 
 ```bash
-st-validate-local
+st-docker-run -- uv run st-validate
 ```
 
-`st-validate-local` is a host orchestrator that dispatches its inner
-validators into the container via `st-docker-run`. Invoke it directly —
-do not wrap it in `st-docker-run`. Fix any failures before proceeding to
+`st-validate` runs inside the container. Invoke it via
+`st-docker-run -- uv run st-validate`. Fix any failures before proceeding to
 the next category or to submission.
 
 ## Failure handling

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -96,7 +96,7 @@ for the canonical split.
 ## Pre-submission
 
 1. Run the repository's canonical validation command if documented
-   (typically `st-validate-local`).
+   (typically `st-docker-run -- uv run st-validate`).
 2. If no canonical command exists, ask the user for the required
    validation steps.
 3. If any check fails, **do not submit** the PR. Fix the failures

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -96,9 +96,9 @@ caching.
 
 If you're unsure where a tool belongs: is it primarily a wrapper around a
 containerized language toolchain (→ container), or a thin Python/shell
-driver around git/gh/SSH-using operations (→ host)? `st-validate-local`
-itself is a host orchestrator that dispatches its inner validators into
-the container — host driver, container payloads.
+driver around git/gh/SSH-using operations (→ host)? `st-validate`
+runs inside the container via `st-docker-run -- uv run st-validate` —
+all validation payloads execute in-container.
 
 ### Examples
 


### PR DESCRIPTION
# Pull Request

## Summary

- Replace all non-historical st-validate-local references with canonical st-docker-run -- uv run st-validate

## Issue Linkage

- Ref #268

## Testing

- markdownlint

## Notes

- # Pull Request

## Summary

- Replace all non-historical `st-validate-local` references with the canonical `st-docker-run -- uv run st-validate` invocation
- Update enforcement hook warning message, skills (dependency-update, pr-workflow, publish), and documentation (skills-architecture, hooks index, skills index)
- Historical artifacts (CHANGELOG, release notes) left untouched per issue spec

## Issue Linkage

- Ref #268
- Cross-repo parent: wphillipmoore/standard-tooling#582

## Testing

- markdownlint
- st-validate (all checks passed)
- Verified no remaining `st-validate-local` references outside historical files

## Notes

- 7 files changed across hooks, skills, and documentation
- The `scripts/dev/*.sh` abstraction layer references were also removed where they appeared alongside `st-validate-local`