### PR TITLE
fix: remove unnecessary uv run prefix from st-docker-run invocations

### DIFF
--- a/docs/development/skills-architecture.md
+++ b/docs/development/skills-architecture.md
@@ -36,7 +36,7 @@ agent or human picks up an issue.
 | Phase | Purpose | Hand-off |
 |---|---|---|
 | B1. Set up workspace | Resolve issue → branch name → **worktree** on a feature branch tied to the issue. One worktree per issue, never on `develop`/`main`. | → B2 |
-| B2. Develop | Edit, validate (`st-docker-run -- uv run st-validate`), iterate, commit (`st-commit`). Multiple commits OK. | → B3 |
+| B2. Develop | Edit, validate (`st-docker-run -- st-validate`), iterate, commit (`st-commit`). Multiple commits OK. | → B3 |
 | B3. Submit | Push, create PR via `st-submit-pr`, link issue with `Fixes`/`Closes`/`Resolves`/`Ref`. Wait for CI green. **Human reviews and merges feature/bugfix PRs.** | → B4 (after merge) |
 | B4. Finalize | `st-finalize-repo`: pull develop, delete merged feature branch, prune worktrees and remotes. | → exit work cycle |
 

--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -141,7 +141,7 @@ split from
   container-only tool is invoked directly — whether bare
   (e.g., `ruff check .`) or wrapped in `st-docker-run --`.
   Both bypass the canonical validation entry point. The correct
-  command is `st-docker-run -- uv run st-validate`, which handles
+  command is `st-docker-run -- st-validate`, which handles
   all tool routing internally.
 
 The canonical tool lists live in
@@ -159,7 +159,7 @@ individual linters — `st-validate` handles tool routing internally.
 
 **Alternative.** For denied commands: invoke the host tool
 directly (drop the `st-docker-run --` prefix). For warned
-commands: use `st-docker-run -- uv run st-validate` instead of invoking
+commands: use `st-docker-run -- st-validate` instead of invoking
 individual linters. See the
 [`publish` skill's host-vs-container section](https://github.com/wphillipmoore/standard-tooling-plugin/blob/develop/skills/publish/SKILL.md#host-vs-container-commands)
 for the canonical split and rationale.

--- a/hooks/scripts/enforce-host-container-split.sh
+++ b/hooks/scripts/enforce-host-container-split.sh
@@ -44,7 +44,7 @@ for tool in "${CONTAINER_TOOLS[@]}"; do
     jq -n --arg tool "$tool" '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        additionalContext: ("WARNING: \($tool) should not be invoked directly. Use st-docker-run -- uv run st-validate for validation — it handles tool routing internally. See issue #168: https://github.com/wphillipmoore/standard-tooling-plugin/issues/168")
+        additionalContext: ("WARNING: \($tool) should not be invoked directly. Use st-docker-run -- st-validate for validation — it handles tool routing internally. See issue #168: https://github.com/wphillipmoore/standard-tooling-plugin/issues/168")
       }
     }'
     exit 0

--- a/skills/dependency-update/SKILL.md
+++ b/skills/dependency-update/SKILL.md
@@ -42,7 +42,7 @@ Most commands in this skill are **host commands** — invoke them directly
 without `st-docker-run` wrapping. This includes `uv`, `gh`, `st-commit`,
 `st-validate`, and all `st-*` workflow tools.
 
-Validation runs via `st-docker-run -- uv run st-validate`, which
+Validation runs via `st-docker-run -- st-validate`, which
 dispatches all checks inside the container. See the
 [`publish` skill's host-vs-container section](../publish/SKILL.md#host-vs-container-commands)
 for the canonical split and rationale
@@ -159,11 +159,11 @@ records:
 After all updates in a category (or after all categories if batching):
 
 ```bash
-st-docker-run -- uv run st-validate
+st-docker-run -- st-validate
 ```
 
 `st-validate` runs inside the container. Invoke it via
-`st-docker-run -- uv run st-validate`. Fix any failures before proceeding to
+`st-docker-run -- st-validate`. Fix any failures before proceeding to
 the next category or to submission.
 
 ## Failure handling

--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -96,7 +96,7 @@ for the canonical split.
 ## Pre-submission
 
 1. Run the repository's canonical validation command if documented
-   (typically `st-docker-run -- uv run st-validate`).
+   (typically `st-docker-run -- st-validate`).
 2. If no canonical command exists, ask the user for the required
    validation steps.
 3. If any check fails, **do not submit** the PR. Fix the failures

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -97,7 +97,7 @@ caching.
 If you're unsure where a tool belongs: is it primarily a wrapper around a
 containerized language toolchain (→ container), or a thin Python/shell
 driver around git/gh/SSH-using operations (→ host)? `st-validate`
-runs inside the container via `st-docker-run -- uv run st-validate` —
+runs inside the container via `st-docker-run -- st-validate` —
 all validation payloads execute in-container.
 
 ### Examples


### PR DESCRIPTION
# Pull Request

## Summary

- st-validate is in PATH inside cached docker images; uv run only needed in standard-tooling itself

## Issue Linkage

- Ref #270

## Testing

- markdownlint

## Notes

- # Pull Request

## Summary

- Remove unnecessary `uv run` prefix from all `st-docker-run -- st-validate` invocations
- `st-validate` is in PATH inside the cached docker image for all consuming repos; `uv run` is only needed in the standard-tooling repo itself
- Also corrected the closed #268 issue body for the historical record

## Issue Linkage

- Ref #270
- Follow-up to #268 (which introduced the incorrect `uv run` prefix)

## Testing

- st-validate (all checks passed)
- Verified no `uv run st-validate` references remain in non-historical files

## Notes

- 6 files changed: same files as #268 minus docs/site/docs/skills/index.md (which correctly used `st-validate` without `uv run`)
- Root cause: parent issue standard-tooling#582 specified `uv run` because that's correct for the standard-tooling repo where it lives, but not for consuming repos
- Cross-repo issue filed: standard-actions#382