### PR TITLE
fix: correct enforcement attribution for auto-close keyword ban in pr-workflow

### DIFF
--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -108,8 +108,11 @@ for the canonical split.
      *timing* of closure, not the *responsibility*: if this PR
      resolves the issue, the agent must close it explicitly after
      finalization (see [Close the issue](#close-the-issue)).
-     The `block-autoclose-linkage` hook enforces the keyword ban
-     mechanically.
+     Enforcement is mechanical: `st-commit` rejects auto-close
+     keywords in commit bodies, and the `st-pr-issue-linkage` CI
+     check rejects them in PR bodies. The plugin's
+     `block-autoclose-linkage` PreToolUse hook adds a further
+     guard at the agent tool-call layer.
 
 ## Submission
 


### PR DESCRIPTION
# Pull Request

## Summary

- Update pr-workflow skill to reflect layered enforcement: st-commit, st-pr-issue-linkage CI check, and plugin hook

## Issue Linkage

- Ref #272

## Testing

- markdownlint

## Notes

- # Pull Request

## Summary

- Correct the pr-workflow skill's enforcement attribution for the auto-close keyword ban
- The skill previously attributed enforcement solely to the `block-autoclose-linkage` hook; updated to reflect the full layered enforcement: `st-commit` (commit body), `st-pr-issue-linkage` (PR body at CI), and the plugin hook (agent tool-call layer)

## Issue Linkage

- Ref #272

## Testing

- markdownlint
- st-validate (all checks passed)

## Notes

- The `block-autoclose-linkage` hook does exist and works — the issue title says "phantom" but the actual problem was incomplete enforcement attribution, not a missing hook
- The hook remains as a belt-and-suspenders guard; the primary enforcement now lives in the wrapper scripts per standard-tooling#594