### PR TITLE
feat: require full triage of st-finalize-repo errors in workflow skills

### DIFF
--- a/skills/pr-workflow/SKILL.md
+++ b/skills/pr-workflow/SKILL.md
@@ -207,11 +207,24 @@ st-finalize-repo
 branch, fast-forward pulls origin, deletes the merged feature
 branch and its worktree, and prunes stale remote-tracking refs.
 
-If the script raises a non-fatal error on a sibling worktree
-(e.g., another agent's in-flight work with uncommitted files),
-verify the develop pull and merged-branch deletion succeeded
-manually with `git log --oneline -3` and `git worktree list`. Do
-not force-remove sibling worktrees.
+### Handling errors and warnings
+
+**Every error and warning from `st-finalize-repo` is serious.**
+There is no such thing as a "pre-existing" or "not my problem"
+error in this ecosystem — any failure that slips through
+represents a bug in the tooling. Do not silently dismiss,
+downplay, or skip past any output that indicates a problem.
+
+If `st-finalize-repo` produces errors or warnings:
+
+1. **Triage** — read the full output and identify what failed
+   and why.
+2. **Report to the user** — surface the triage to the human
+   with the exact error output and your assessment. Do not
+   proceed past finalization until the user has reviewed the
+   errors.
+3. **Do not force-remove sibling worktrees** or use destructive
+   workarounds to make the errors disappear.
 
 ### Verify post-merge async workflows
 

--- a/skills/publish/SKILL.md
+++ b/skills/publish/SKILL.md
@@ -379,6 +379,14 @@ the bookkeeping is still done.
    branches, and prunes stale remotes. Run final validation to
    confirm a clean state.
 
+   **Every error and warning from `st-finalize-repo` is
+   serious.** There is no such thing as a "pre-existing" or
+   "not my problem" error — any failure represents a bug in the
+   tooling. If `st-finalize-repo` produces errors or warnings,
+   triage the full output, then surface your assessment to the
+   user before proceeding. Do not silently dismiss any output
+   that indicates a problem.
+
 3. **Continue to Phase 7.** Phase 6 alone does not conclude the
    cycle; the producer-side hand-off in Phase 7 is the actual
    release boundary for consumers.


### PR DESCRIPTION
# Pull Request

## Summary

- Both pr-workflow and publish skills now require all st-finalize-repo errors to be triaged and reported to the human

## Issue Linkage

- Ref #266

## Testing

- markdownlint

## Notes

- # Pull Request

## Summary

- Add explicit guidance to both pr-workflow and publish skills that all `st-finalize-repo` errors and warnings must be triaged and reported to the human
- Zero tolerance for silently dismissed errors — no "pre-existing" or "not my problem" exception
- Same posture in both skills: triage the output, surface assessment to the user, do not proceed until reviewed

## Issue Linkage

- Ref #266

## Testing

- markdownlint
- st-validate (all checks passed)

## Notes

- pr-workflow: replaced the narrow "sibling worktree" error handling with a general "all errors are serious" section
- publish: added an inline guidance block after the `st-finalize-repo` step in Phase 6