### PR TITLE
chore: bump version to 1.4.25

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "standard-tooling",
   "description": "Shared hooks, skills, agents, and commands for all managed repositories in the standard-tooling ecosystem.",
-  "version": "1.4.24",
+  "version": "1.4.25",
   "author": {
     "name": "wphillipmoore"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [1.4.24] - 2026-05-11
+
+### Chores
+
+- bump version to 1.4.24
+
+### Refactoring
+
+- align skill with template redesign
+- align PR and issue templates with standard-tooling
+
 ## [1.4.23] - 2026-05-09
 
 ### Bug fixes

--- a/releases/v1.4.24.md
+++ b/releases/v1.4.24.md
@@ -1,0 +1,23 @@
+
+# Release 1.4.24 (2026-05-11)
+
+## Chores
+
+- **bump version to 1.4.24**
+
+## Refactoring
+
+- **align skill with template redesign**
+The PR template is now a stub — st-submit-pr constructs the entire
+body from CLI arguments. Removed guidance telling agents to locate
+and populate the template. Replaced with explicit st-submit-pr
+argument preparation.
+
+Ref wphillipmoore/standard-tooling#650
+
+- **align PR and issue templates with standard-tooling**
+Replace PR template with redirect stub (st-submit-pr is the
+required path). Redesign issue template as 3-field form with
+standardized type dropdown.
+
+Ref wphillipmoore/standard-tooling#650


### PR DESCRIPTION
# Pull Request

## Summary

- Manual version bump after automated bump PR failed due to GitHub API 504 during tracking issue auto-discovery. Merges main back into develop to pick up v1.4.24 release tag and changelog.

## Issue Linkage

- Ref #299

## Notes

- -