### PR TITLE
fix: add vergil-tooling key to vergil.toml dependencies

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vergil",
   "description": "Shared hooks, skills, agents, and commands for all managed repositories in the vergil-tooling ecosystem.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": {
     "name": "vergil-project"
   },

--- a/vergil.toml
+++ b/vergil.toml
@@ -25,3 +25,4 @@ integration-tests = false
 
 [dependencies]
 vergil = "v2.0"
+vergil-tooling = "v2.0"


### PR DESCRIPTION
# Pull Request

## Summary

- Add missing vergil-tooling key to [dependencies] in vergil.toml, matching the pattern used in all other vergil-project repos. This fixes vrg-github-config audit failures that block the publish workflow.

## Issue Linkage

- Ref #307

## Notes

- -