### PR TITLE
chore: next-cycle dependency updates for 2.0.1

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -24,5 +24,5 @@ versions = ["latest"]
 integration-tests = false
 
 [dependencies]
-vergil = "v2.0"
-vergil-tooling = "v2.0"
+vergil = "v2.0.5"
+vergil-tooling = "v2.0.5"


### PR DESCRIPTION
# Pull Request

## Summary

- Update vergil and vergil-tooling dependency versions from v2.0 to v2.0.5 in vergil.toml. No other toolchain dependencies require updates — CI action pins use floating major tags already at latest.

## Issue Linkage

- Ref #309

## Notes

- -