### PR TITLE
fix: correct marketplace name in consumer-refresh sequence

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -12,7 +12,7 @@ agent = "Co-Authored-By: wphillipmoore-agent <284101533+wphillipmoore-agent@user
 release = true
 docs = true
 consumer-refresh = """\
-/plugin marketplace update vergil-tooling-marketplace
+/plugin marketplace update vergil-marketplace
 
 Note: /reload-plugins is currently buggy — it reloads skills but \
 does not reliably pick up hook changes. To fully apply the update, \


### PR DESCRIPTION
# Pull Request

## Summary

- Fix consumer-refresh in vergil.toml: change vergil-tooling-marketplace to vergil-marketplace. The old name was left over from the org rename and causes the Phase 7 hand-off command to fail.

## Issue Linkage

- Ref #313

## Notes

- -