### PR TITLE
chore: next-cycle dependency updates for 2.0.2

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -24,5 +24,5 @@ versions = ["latest"]
 integration-tests = false
 
 [dependencies]
-vergil = "v2.0.5"
-vergil-tooling = "v2.0.5"
+vergil = "v2.0.6"
+vergil-tooling = "v2.0.6"


### PR DESCRIPTION
# Pull Request

## Summary

- Update vergil and vergil-tooling dependency versions from v2.0.5 to v2.0.6 in vergil.toml.

## Issue Linkage

- Ref #315

## Notes

- -