### PR TITLE
chore(deps): pin vergil to minor version, drop vergil-tooling key

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -24,5 +24,4 @@ versions = ["latest"]
 integration-tests = false
 
 [dependencies]
-vergil = "v2.0.6"
-vergil-tooling = "v2.0.6"
+vergil = "v2.0"


### PR DESCRIPTION
# Pull Request

## Summary

- Pin vergil dependency to v2.0 (minor, not patch) and remove the redundant vergil-tooling key

## Issue Linkage

- Ref #319

## Notes

- Pins vergil to v2.0 instead of v2.0.6 — patch-level pinning is not the normal convention. Removes the redundant vergil-tooling key now that vergil-tooling#755 consolidated to a single vergil key.