### PR TITLE
feat(permissions): deploy permission model and update hook messages

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,9 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(vrg-*)"
+    ]
+  },
   "extraKnownMarketplaces": {
     "vergil-marketplace": {
       "source": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,15 @@ cold and is most useful as a reference at the moment work begins.
 
 ## Shell command policy
 
+Use `vrg-git` instead of `git` for all git operations. Use `vrg-gh`
+instead of `gh` for all GitHub CLI operations. These wrappers enforce
+subcommand allowlists, flag deny lists, credential selection, and
+audit logging.
+
+Raw `git` and `gh` are denied by the permission model. If a command
+is not available through the wrappers, explain the situation to the
+human who can run it directly via `! <command>` in the prompt.
+
 **Do NOT use heredocs** (`<<EOF` / `<<'EOF'`) for multi-line arguments to CLI
 tools such as `gh`, `git commit`, or `curl`. Always write multi-line content
 to a temporary file and pass it via `--body-file` or `--file` instead.

--- a/hooks/scripts/block-agent-merge.sh
+++ b/hooks/scripts/block-agent-merge.sh
@@ -2,6 +2,7 @@
 # block-agent-merge.sh — PreToolUse hook for Bash.
 # Blocks gh pr merge and gh pr review --approve on non-release PRs.
 # Delegates branch verification to vrg-check-pr-merge.
+# Note: vrg-gh also rejects pr merge for non-escalated contexts.
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
 # vergil.toml.

--- a/hooks/scripts/block-github-contents-api.sh
+++ b/hooks/scripts/block-github-contents-api.sh
@@ -58,7 +58,7 @@ if [ "$has_contents_url" = true ] && [ "$has_write_method" = true ]; then
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
-      permissionDecisionReason: "Direct writes to the GitHub Contents API are blocked. File changes must go through the local workflow: edit files in your worktree, commit with vrg-commit, and submit with vrg-submit-pr.\n\nSee docs/specs/worktree-convention.md in vergil-tooling for the full convention."
+      permissionDecisionReason: "Direct writes to the GitHub Contents API are blocked. File changes must go through the local workflow: edit files in your worktree, commit with vrg-commit, and submit with vrg-submit-pr. Note: vrg-gh denies gh api entirely.\n\nSee docs/specs/worktree-convention.md in vergil-tooling for the full convention."
     }
   }'
 else

--- a/hooks/scripts/block-raw-gh-pr-create.sh
+++ b/hooks/scripts/block-raw-gh-pr-create.sh
@@ -30,10 +30,10 @@ deny() {
 }
 
 if echo "$command" | grep -qE '(^|[;&|]\s*)gh\s+pr\s+create(\s|$)'; then
-  deny "Raw gh pr create is blocked. Use vrg-submit-pr instead. See vergil.toml for usage."
+  deny "Raw gh pr create is blocked. Use vrg-submit-pr instead. All gh operations should use vrg-gh, which enforces subcommand allowlists, credential selection, and audit logging."
 elif echo "$command" | grep -qE 'gh\s+api\s+.*(/pulls)(\s|$)' \
   && echo "$command" | grep -qiE '(-X\s+POST|--method\s+POST|-XPOST)'; then
-  deny "gh api POST to /pulls is equivalent to gh pr create and is blocked. Use vrg-submit-pr instead."
+  deny "gh api POST to /pulls is equivalent to gh pr create and is blocked. Use vrg-submit-pr instead. All gh operations should use vrg-gh."
 else
   exit 0
 fi

--- a/hooks/scripts/block-raw-git-commit.sh
+++ b/hooks/scripts/block-raw-git-commit.sh
@@ -26,7 +26,7 @@ if echo "$command" | grep -qE '(^|[;&|]\s*)git\s+commit(\s|$)'; then
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "deny",
-      permissionDecisionReason: "Raw git commit is blocked. Use vrg-commit instead. See vergil.toml for usage."
+      permissionDecisionReason: "Raw git commit is blocked. Use vrg-commit instead. All git operations should use vrg-git, which enforces subcommand allowlists and audit logging."
     }
   }'
 else


### PR DESCRIPTION
# Pull Request

## Summary

- Deploy permission model and update hook messages

## Issue Linkage

- Ref #336

## Notes

- Deploy the VERGIL org permission model to vergil-claude-plugin and update hook error messages to reference the new wrappers.

- Add `Bash(vrg-*)` project-level allowlist to `.claude/settings.json`
- Add shell command policy section to CLAUDE.md directing agents to use `vrg-git`/`vrg-gh` wrappers
- Update `block-raw-git-commit` message: note all git operations should use `vrg-git`
- Update `block-raw-gh-pr-create` message: note all gh operations should use `vrg-gh`
- Update `block-agent-merge` header: note `vrg-gh` also rejects `pr merge` for non-escalated contexts
- Update `block-github-contents-api` message: note `vrg-gh` denies `gh api` entirely

Part of the org-wide permission model rollout (vergil-project/vergil-tooling#754, Tasks 6-8).