### PR TITLE
chore(docs): add label to version selector in site header

### DIFF
--- a/docs/site/docs/stylesheets/extra.css
+++ b/docs/site/docs/stylesheets/extra.css
@@ -1,0 +1,7 @@
+.md-version::before {
+  content: "Version:";
+  margin-right: 0.4em;
+  font-size: 0.8rem;
+  color: var(--md-primary-bg-color);
+  opacity: 0.7;
+}

--- a/docs/site/mkdocs.yml
+++ b/docs/site/mkdocs.yml
@@ -12,6 +12,8 @@ edit_uri: ""
 extra:
   version:
     provider: mike
+extra_css:
+  - stylesheets/extra.css
 
 plugins:
   - search


### PR DESCRIPTION
# Pull Request

## Summary

- Add CSS label to the MkDocs Material version selector, matching vergil-tooling#920

## Issue Linkage

- Ref #355

## Notes

- Adds a Version: label via CSS ::before pseudo-element on .md-version, matching the implementation shipped in vergil-tooling#920.