### PR TITLE
chore(config): add consumer-refresh config to vergil.toml

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -5,6 +5,12 @@ branching-model = "library-release"
 release-model = "tagged-release"
 primary-language = "claude-plugin"
 
+[publish]
+consumer-refresh = """\
+/plugin marketplace update vergil-tooling-marketplace
+/reload-plugins
+"""
+
 [ci]
 versions = ["latest"]
 integration-tests = false


### PR DESCRIPTION
# Pull Request

## Summary

- Add [publish].consumer-refresh so tooling can surface the plugin refresh sequence after merges and releases

## Issue Linkage

- Ref #369

## Notes

- -