### PR TITLE
chore(ci): add missing container parameters and fix stale standards doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       language: claude-plugin
       versions: '["latest"]'
       container-suffix: base
+      container-tag: 'latest'
 
   security:
     uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
@@ -53,6 +54,8 @@ jobs:
       run-codeql: false
       run-standards: ${{ inputs.run-release != 'false' }}
       run-security: ${{ inputs.run-security != 'false' }}
+      container-suffix: base
+      container-tag: 'latest'
     permissions:
       contents: read
       security-events: write
@@ -62,3 +65,5 @@ jobs:
     with:
       language: claude-plugin
       run-release: ${{ inputs.run-release != 'false' }}
+      container-suffix: base
+      container-tag: 'latest'

--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -51,14 +51,13 @@ Do not construct commit messages or PR bodies manually.
 
 ```bash
 vrg-commit \
-  --type TYPE --message MESSAGE --agent AGENT \
-  [--scope SCOPE] [--body BODY]
+  --type TYPE --scope SCOPE --message MESSAGE \
+  [--body BODY]
 ```
 
-- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build`
+- `--type` (required): `feat|fix|docs|style|refactor|test|chore|ci|build|revert`
+- `--scope` (required): conventional commit scope
 - `--message` (required): commit description
-- `--agent` (required): `claude` or `codex`
-- `--scope` (optional): conventional commit scope
 - `--body` (optional): detailed commit body
 
 The script resolves the correct `Co-Authored-By` identity from
@@ -68,18 +67,17 @@ The script resolves the correct `Co-Authored-By` identity from
 
 ```bash
 vrg-submit-pr \
-  --issue NUMBER --summary TEXT \
-  [--linkage KEYWORD] [--title TEXT] \
-  [--notes TEXT] [--dry-run]
+  --issue NUMBER --title TEXT --summary TEXT \
+  [--linkage KEYWORD] [--notes TEXT] [--dry-run]
 ```
 
 - `--issue` (required): GitHub issue number (just the number)
+- `--title` (required): PR title
 - `--summary` (required): one-line PR summary
 - `--linkage` (optional, default: `Ref`): **always use `Ref`**.
   `Fixes`, `Closes`, and `Resolves` are forbidden — they auto-close
   the issue at merge time, bypassing finalization. Issues are closed
   explicitly after `vrg-finalize-repo` succeeds.
-- `--title` (optional): PR title (default: most recent commit subject)
 - `--notes` (optional): additional notes
 - `--dry-run` (optional): print generated PR without executing
 


### PR DESCRIPTION
# Pull Request

## Summary

- Add container-tag and container-suffix to reusable workflow calls and fix stale vrg-commit/vrg-submit-pr docs

## Issue Linkage

- Ref #383

## Notes

- Addresses vergil-project/vergil-tooling#1015, vergil-project/vergil-tooling#1013, and vergil-project/vergil-tooling#976. CI: quality was missing container-tag; security and version were missing both. Standards doc: removed nonexistent --agent flag, made --scope and --title required, added revert to allowed types.