### PR TITLE
fix(hooks): replace /dev/stdin with cat in block-heredoc hook

### DIFF
--- a/hooks/scripts/block-heredoc.sh
+++ b/hooks/scripts/block-heredoc.sh
@@ -5,7 +5,8 @@
 # and special characters. Write to a temp file and use --body-file instead.
 set -euo pipefail
 
-command=$(jq -r '.tool_input.command' < /dev/stdin)
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command')
 
 # Match heredoc operators: <<EOF, <<'EOF', <<"EOF", <<-EOF, etc.
 # But not << used in other contexts (e.g., bitshift in Python/etc.).


### PR DESCRIPTION
# Pull Request

## Summary

- /dev/stdin does not exist in the hook execution environment, causing a non-blocking error on every Bash tool call. Replaced with the standard input=$(cat) pattern used by all other hook scripts.

## Issue Linkage

- Ref #387

## Notes

- -