### PR TITLE
fix(CLAUDE.md): align template section with vrg-container-run rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Rules for this session:
   read-only — all changes flow through your worktree on your
   feature branch.
 - When you need to run validation, run it from inside your worktree
-  (vrg-docker-run mounts the current directory).
+  (vrg-container-run mounts the current directory).
 ```
 
 All fields are required.
@@ -97,7 +97,7 @@ human who can run it directly via `! <command>` in the prompt.
 ## Validation
 
 ```bash
-vrg-docker-run -- vrg-validate
+vrg-container-run -- vrg-validate
 ```
 
 This is the **only** validation command. Do not run individual linters,


### PR DESCRIPTION
# Pull Request

## Summary

- Replace two stale vrg-docker-run references with vrg-container-run to match the updated consumer template

## Issue Linkage

- Ref #394

## Notes

- The consumer template in vergil-tooling was updated to use vrg-container-run (renamed from vrg-docker-run), but the template-embedded section of CLAUDE.md still referenced the old name. The verbatim substring match in the audit check caused the release preflight to fail.