### PR TITLE
chore(ci): revert container-prefix dev workaround

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,14 +15,10 @@ permissions:
 jobs:
   docs:
     uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
-    with:
-      container-prefix: dev
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
     uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
-    with:
-      container-prefix: dev
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
     with:
       language: claude-plugin
       versions: '["latest"]'
-      container-prefix: dev
       container-suffix: base
       container-tag: 'latest'
 
@@ -55,7 +54,6 @@ jobs:
       run-codeql: false
       run-standards: ${{ inputs.run-release != 'false' }}
       run-security: ${{ inputs.run-security != 'false' }}
-      container-prefix: dev
       container-suffix: base
       container-tag: 'latest'
     permissions:
@@ -67,6 +65,5 @@ jobs:
     with:
       language: claude-plugin
       run-release: ${{ inputs.run-release != 'false' }}
-      container-prefix: dev
       container-suffix: base
       container-tag: 'latest'


### PR DESCRIPTION
# Pull Request

## Summary

- Remove container-prefix: dev overrides from ci.yml and cd.yml. Prod images are now live, so jobs use the default prod prefix. This PR also validates that the new vergil-actions v2.0 tag works correctly end-to-end.

## Issue Linkage

- Ref #410

## Notes

- -