### PR TITLE
chore(deps): migrate vergil pin and workflow refs to v2.1

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,11 +14,11 @@ permissions:
 
 jobs:
   docs:
-    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-docs.yml@v2.1
     permissions:
       contents: write
 
   release:
     if: github.ref == 'refs/heads/main'
-    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/cd-release.yml@v2.1
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: docs/site
 
   quality:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-quality.yml@v2.1
     with:
       language: claude-plugin
       versions: '["latest"]'
@@ -48,7 +48,7 @@ jobs:
       container-tag: 'latest'
 
   security:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-security.yml@v2.1
     with:
       language: claude-plugin
       run-codeql: false
@@ -61,7 +61,7 @@ jobs:
       security-events: write
 
   version:
-    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.0
+    uses: vergil-project/vergil-actions/.github/workflows/ci-version-bump.yml@v2.1
     with:
       language: claude-plugin
       run-release: ${{ inputs.run-release != 'false' }}

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ for the rationale.
 | `block-protected-branch-work` | PreToolUse/Bash | Blocks commits from outside `.worktrees/*` on repos that adopt the worktree convention; otherwise blocks commits on `develop`/`main` |
 | `block-heredoc` | PreToolUse/Bash | Blocks `<<EOF` in CLI args (use `--body-file` or `$(cat <file>)`) |
 | `block-associative-arrays` | PreToolUse/Bash | Blocks bash 4+ associative arrays — host scripts must run on macOS bash 3.2 |
-| `enforce-host-container-split` | PreToolUse/Bash | Denies wrapping host-only tools in `vrg-docker-run`; warns on bare container-only tools |
+| `enforce-host-container-split` | PreToolUse/Bash | Denies wrapping host-only tools in `vrg-container-run`; warns on bare container-only tools |
 | `block-autoclose-linkage` | PreToolUse/Bash | Blocks `--linkage Fixes/Closes/Resolves` in `vrg-submit-pr` — use `Ref` instead |
 | `remind-finalize` | PostToolUse/Bash | After `vrg-submit-pr`, reminds to run `vrg-finalize-repo` |
 | `detect-deprecation-warnings` | PostToolUse/Bash | Surfaces deprecation warnings from test output for triage |
@@ -159,7 +159,7 @@ Full reference:
 
 | Agent | Purpose |
 |---|---|
-| `bootstrap` | Session-start preflight: repository profile, branch state, dispatcher availability, standards reference, git hooks |
+| `bootstrap` | Session-start preflight: repository profile, branch state, standards reference, hook guard availability |
 
 ## Plugin namespace
 
@@ -177,7 +177,7 @@ Example: `/vergil:implement`.
   — Python CLIs, bash validators, git hooks (consumed via PATH).
 - [`vergil-docker`](https://github.com/vergil-project/vergil-docker)
   — Dev container images (`ghcr.io/vergil-project/dev-python`, `dev-go`,
-  etc.) that `vrg-docker-run` dispatches into.
+  etc.) that `vrg-container-run` dispatches into.
 - [`vergil-actions`](https://github.com/vergil-project/vergil-actions)
   — Shared GitHub Actions composite actions consumed by CI.
 

--- a/docs/development/skills-architecture.md
+++ b/docs/development/skills-architecture.md
@@ -36,7 +36,7 @@ agent or human picks up an issue.
 | Phase | Purpose | Hand-off |
 |---|---|---|
 | B1. Set up workspace | Resolve issue → branch name → **worktree** on a feature branch tied to the issue. One worktree per issue, never on `develop`/`main`. | → B2 |
-| B2. Develop | Edit, validate (`vrg-docker-run -- vrg-validate`), iterate, commit (`vrg-commit`). Multiple commits OK. | → B3 |
+| B2. Develop | Edit, validate (`vrg-container-run -- vrg-validate`), iterate, commit (`vrg-commit`). Multiple commits OK. | → B3 |
 | B3. Submit | Push, create PR via `vrg-submit-pr`, link issue with `Fixes`/`Closes`/`Resolves`/`Ref`. Wait for CI green. **Human reviews and merges feature/bugfix PRs.** | → B4 (after merge) |
 | B4. Finalize | `vrg-finalize-repo`: pull develop, delete merged feature branch, prune worktrees and remotes. | → exit work cycle |
 

--- a/docs/development/starting-work-on-an-issue.md
+++ b/docs/development/starting-work-on-an-issue.md
@@ -41,9 +41,10 @@ and you are at the repo root with a clean main worktree:
 gh issue view <N> --json number,title,state --jq '.'
 
 # 2. Decide branch type from issue context — feature is the
-#    default; use bugfix for non-urgent defect fixes; hotfix only
-#    for production-blocking issues branched from main
-TYPE=feature   # or bugfix | hotfix
+#    default; use bugfix for non-urgent defect fixes; chore for
+#    maintenance work (version bumps, migrations, tooling); hotfix
+#    only for production-blocking issues branched from main
+TYPE=feature   # or bugfix | chore | hotfix
 
 # 3. Construct a kebab-case slug from the issue title
 #    (2–4 tokens, keep the full branch name under 60 chars)
@@ -56,10 +57,10 @@ git worktree add ".worktrees/issue-${N}-${SLUG}" \
 ```
 
 Pre-warm the dev container cache for the new branch so the first
-`vrg-docker-run` invocation is fast:
+`vrg-container-run` invocation is fast:
 
 ```bash
-cd ".worktrees/issue-${N}-${SLUG}" && vrg-docker-cache build
+cd ".worktrees/issue-${N}-${SLUG}" && vrg-container-cache build
 ```
 
 Then either:
@@ -205,6 +206,7 @@ git fetch origin --quiet
 remote_branch=$(git branch -r --list \
   "origin/feature/${issue_number}-*" \
   "origin/bugfix/${issue_number}-*" \
+  "origin/chore/${issue_number}-*" \
   "origin/hotfix/${issue_number}-*" \
   | head -1 | sed 's|.*origin/||')
 ```

--- a/docs/site/docs/agents/index.md
+++ b/docs/site/docs/agents/index.md
@@ -21,13 +21,10 @@ code changes are made.
 2. **Branch State** — reports the current branch and warns if on a protected
    branch (`main` or `develop`)
 
-3. **Host Dispatcher** — verifies `vrg-docker-run` is available on PATH
-   (the host-side dispatcher for container-routed validation)
-
-4. **Standards and Conventions** — checks if the standards repo is available
+3. **Standards and Conventions** — checks if the standards repo is available
    locally at `../standards-and-conventions`
 
-5. **Hook Guard** — verifies `vrg-hook-guard` is available
+4. **Hook Guard** — verifies `vrg-hook-guard` is available
 
 ### Status Report
 
@@ -39,7 +36,6 @@ Repository:    <repo name>
 Profile:       <repository_type> | <branching_model> | <primary_language>
 Branch:        <current branch> [WARNING if protected]
 Validation:    <validation command or "not configured">
-vrg-docker-run: <available or "NOT FOUND">
 Standards:     <local or web fallback>
 Git hooks:     <hooks path or "NOT CONFIGURED">
 =========================

--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -115,7 +115,7 @@ reference it: `--body-file /tmp/body.txt` or
 **What.** Denies Bash tool invocations that use bash 4+ associative
 arrays (`declare -A`, `typeset -A`).
 
-**Why.** The hook scripts and `vrg-docker-run` dispatcher themselves
+**Why.** The hook scripts and `vrg-container-run` dispatcher themselves
 run on the host shell, which on macOS is bash 3.2 (Apple has not
 shipped a newer bash since the GPL license change). Associative
 arrays silently fail on macOS bash 3.2, producing hard-to-debug
@@ -133,15 +133,15 @@ language-toolchain command against the canonical host-vs-container
 split from
 [#96](https://github.com/vergil-project/vergil-claude-plugin/issues/96).
 
-- **Denies** wrapping a host-only tool in `vrg-docker-run --`
-  (e.g., `vrg-docker-run -- gh issue list`). The host tool needs
+- **Denies** wrapping a host-only tool in `vrg-container-run --`
+  (e.g., `vrg-container-run -- gh issue list`). The host tool needs
   SSH-agent, host git config, or host `gh` auth — the container
   can't satisfy those.
 - **Warns** (via `additionalContext`, not deny) when a
   container-only tool is invoked directly — whether bare
-  (e.g., `ruff check .`) or wrapped in `vrg-docker-run --`.
+  (e.g., `ruff check .`) or wrapped in `vrg-container-run --`.
   Both bypass the canonical validation entry point. The correct
-  command is `vrg-docker-run -- vrg-validate`, which handles
+  command is `vrg-container-run -- vrg-validate`, which handles
   all tool routing internally.
 
 The canonical tool lists live in
@@ -154,12 +154,12 @@ being the only enforcement mechanism. Issue
 [#168](https://github.com/vergil-project/vergil-claude-plugin/issues/168)
 extended this to also catch agents bypassing the canonical
 validation entry point by calling linters directly (even correctly
-wrapped in `vrg-docker-run`). The agent should never invoke
+wrapped in `vrg-container-run`). The agent should never invoke
 individual linters — `vrg-validate` handles tool routing internally.
 
 **Alternative.** For denied commands: invoke the host tool
-directly (drop the `vrg-docker-run --` prefix). For warned
-commands: use `vrg-docker-run -- vrg-validate` instead of invoking
+directly (drop the `vrg-container-run --` prefix). For warned
+commands: use `vrg-container-run -- vrg-validate` instead of invoking
 individual linters.
 
 ### block-autoclose-linkage

--- a/hooks/scripts/enforce-host-container-split.sh
+++ b/hooks/scripts/enforce-host-container-split.sh
@@ -2,8 +2,8 @@
 # enforce-host-container-split.sh — PreToolUse hook for Bash.
 # Enforces the host-vs-container tool routing rule from #96.
 #
-# - DENY: wrapping a host-only tool in vrg-docker-run --
-# - WARN: bare-invoking a container-only tool without vrg-docker-run --
+# - DENY: wrapping a host-only tool in vrg-container-run --
+# - WARN: bare-invoking a container-only tool without vrg-container-run --
 #
 # Gated on managed-repo detection (#87): no-op in repos that lack
 # vergil.toml.
@@ -24,14 +24,14 @@ fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
 
-# Check for host tools wrapped in vrg-docker-run -- (DENY)
+# Check for host tools wrapped in vrg-container-run -- (DENY)
 for tool in "${HOST_TOOLS[@]}"; do
-  if echo "$command" | grep -qE "(^|[;&|]\s*)vrg-docker-run\s+--\s+$tool(\s|$)"; then
+  if echo "$command" | grep -qE "(^|[;&|]\s*)vrg-container-run\s+--\s+$tool(\s|$)"; then
     jq -n --arg tool "$tool" '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "deny",
-        permissionDecisionReason: ("\($tool) is a host command — invoke directly without vrg-docker-run wrapping. See issue #96: https://github.com/vergil-project/vergil-claude-plugin/issues/96")
+        permissionDecisionReason: ("\($tool) is a host command — invoke directly without vrg-container-run wrapping. See issue #96: https://github.com/vergil-project/vergil-claude-plugin/issues/96")
       }
     }'
     exit 0
@@ -40,11 +40,11 @@ done
 
 # Check for container tools invoked directly (WARN)
 for tool in "${CONTAINER_TOOLS[@]}"; do
-  if echo "$command" | grep -qE "(^|[;&|]\s*)(vrg-docker-run\s+--\s+)?$tool(\s|$)"; then
+  if echo "$command" | grep -qE "(^|[;&|]\s*)(vrg-container-run\s+--\s+)?$tool(\s|$)"; then
     jq -n --arg tool "$tool" '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
-        additionalContext: ("WARNING: \($tool) should not be invoked directly. Use vrg-docker-run -- vrg-validate for validation — it handles tool routing internally. See issue #168: https://github.com/vergil-project/vergil-claude-plugin/issues/168")
+        additionalContext: ("WARNING: \($tool) should not be invoked directly. Use vrg-container-run -- vrg-validate for validation — it handles tool routing internally. See issue #168: https://github.com/vergil-project/vergil-claude-plugin/issues/168")
       }
     }'
     exit 0

--- a/hooks/scripts/lib/host-container-tools.sh
+++ b/hooks/scripts/lib/host-container-tools.sh
@@ -10,13 +10,11 @@
 # Host-only: release/git workflow tools, thin gh/git wrappers.
 # shellcheck disable=SC2034
 HOST_TOOLS=(
-  vrg-prepare-release
   vrg-commit
   vrg-submit-pr
   vrg-finalize-repo
-  vrg-merge-when-green
   vrg-wait-until-green
-  vrg-docker-run
+  vrg-container-run
   vrg-ensure-label
   gh
   git

--- a/vergil.toml
+++ b/vergil.toml
@@ -15,4 +15,4 @@ versions = ["latest"]
 integration-tests = false
 
 [dependencies]
-vergil = "v2.0"
+vergil = "v2.1"


### PR DESCRIPTION
# Pull Request

## Summary

- Bump vergil.toml pin v2.0 -> v2.1, update five consumed vergil-actions workflow refs to @v2.1, and clean up vrg-docker-run rename drift (dead hook guard + stale docs).

## Issue Linkage

- Ref #428

## Notes

- Pin-plus-workflow-refs migration per vergil-tooling#1371; no VERSION bump needed (develop 2.1.2 already diverged from main 2.1.1). Rides along: enforce-host-container-split hook re-pointed from dead vrg-docker-run to vrg-container-run (guard was silently inert), two dead HOST_TOOLS entries dropped, docs swept, bootstrap-agent docs corrected. Known deferred drift: vrg-finalize-repo references (semantic rewrite needed). vrg-validate green.