### PR TITLE
docs(standards): close out vrg-finalize-repo references (residual from #441)

### DIFF
--- a/docs/repository-standards.md
+++ b/docs/repository-standards.md
@@ -77,7 +77,7 @@ vrg-submit-pr \
 - `--linkage` (optional, default: `Ref`): **always use `Ref`**.
   `Fixes`, `Closes`, and `Resolves` are forbidden — they auto-close
   the issue at merge time, bypassing finalization. Issues are closed
-  explicitly after `vrg-finalize-repo` succeeds.
+  explicitly by the human after PR finalization (`vrg-finalize-pr`).
 - `--notes` (optional): additional notes
 - `--dry-run` (optional): print generated PR without executing
 


### PR DESCRIPTION
# Pull Request

## Summary

- Fix the last live vrg-finalize-repo reference (docs/repository-standards.md linkage rationale) -- the one #438 item the #441 drift-repair sweep missed.

## Issue Linkage

- Ref #438

## Notes

- Everything else in #438 was implemented by #441 / PR #444 (hook scripts, README, starting-work doc, hooks reference; remind-finalize retired outright rather than reworded). After this merges, #438 is fully addressed and closeable.