### PR TITLE
fix(hooks): stop command matchers false-matching quoted multi-line arguments

### DIFF
--- a/docs/plans/2026-06-05-450-matcher-quoted-args.md
+++ b/docs/plans/2026-06-05-450-matcher-quoted-args.md
@@ -1,0 +1,1760 @@
+# Command-Matcher Quoting Fix (#450) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop PreToolUse hook matchers from false-positive-matching
+tool names that appear inside quoted multi-line arguments, per
+`docs/specs/2026-06-05-450-command-matcher-quoting-design.md`.
+
+**Architecture:** One shared bash helper (`strip_quoted_segments` in
+`hooks/scripts/lib/command-match.sh`) removes quoted spans from the
+command text; each hook script's existing tool-name regex then runs
+against the stripped text with the hardened anchor
+`(^|[;&|({]\s*)`. Argument-content predicates (URLs, method flags,
+`--linkage` values, `cd`/`git -C` path extraction) keep matching raw
+text. The vergil-tooling half (`vrg-hook-guard`) is a separate
+sub-issue filed in Task 13 and implemented in that repo.
+
+**Tech Stack:** bash 3.2-compatible shell, jq (Oniguruma regex,
+already a hard dependency of every hook script), `grep -E`,
+table-driven bash tests per the `guard-audit-writes.test.sh`
+convention.
+
+---
+
+## Execution rules for this repo (read first)
+
+1. **Worktree.** All paths below are relative to the worktree root:
+   `/Users/pmoore/dev/projects/vergil-project/vergil-claude-plugin/.worktrees/issue-450-matcher-quoted-args/`
+   Use absolute worktree paths for Read/Edit/Write; `cd` into the
+   worktree for every Bash command. Never edit the project root.
+2. **Commits.** Never raw `git commit` — always `vrg-git add …` then
+   `vrg-commit --type … --scope … --message … [--body …]`. Never raw
+   `gh` — always `vrg-gh`.
+3. **Live-fire hazard.** The hooks this plan fixes scan *your* Bash
+   command strings, and until the fix ships they still have the
+   #450 bug. Practical consequences while executing this plan:
+   - Never start a line inside a quoted `--body` argument with a
+     tool name (`git commit`, `gh pr create`, `vrg-submit-pr`,
+     `pytest`, `declare -A`, …). Keep commit bodies to a single
+     paragraph.
+   - `vrg-hook-guard` (host) additionally denies commands containing
+     bare `git`/`gh` tokens even mid-word after `.`/`/` (e.g.
+     `find . -path ./.git`). Avoid such tokens in your commands; use
+     the Read/Write/Edit tools instead of shell text processing.
+   - Heredocs are blocked repo-wide. Multi-line content goes through
+     the Write tool into a file, passed via `--body-file`.
+4. **Validation.** `vrg-container-run -- vrg-validate` is the only
+   validation command. The bash test suites can also be run directly
+   (`bash hooks/tests/<name>.test.sh`) for fast TDD loops — they
+   need only jq, grep, and git.
+5. **Spec.** The authoritative design, canonical case table, and
+   accepted gaps:
+   `docs/specs/2026-06-05-450-command-matcher-quoting-design.md`.
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| Create `hooks/scripts/lib/command-match.sh` | the `strip_quoted_segments` helper — the single seam where the fix lives |
+| Create `hooks/tests/command-match.test.sh` | stripper unit tests (spec §6.2) |
+| Create `hooks/tests/command-matchers.test.sh` | per-script allow/deny integration tests (spec §6.3) |
+| Modify 9 scripts under `hooks/scripts/` | point tool-name predicates at stripped text (spec §3.2 table) |
+| Create `scripts/bin/validate-custom` | wires `hooks/tests/*.test.sh` into `vrg-validate` (spec §6.5) |
+| Modify `docs/site/docs/hooks/index.md` | document quote-stripped matching |
+| Modify `docs/specs/2026-06-05-450-command-matcher-quoting-design.md` | record the filed vergil-tooling sub-issue number |
+
+`block-heredoc.sh` is intentionally untouched (spec §3.2: stripping
+would break quoted-delimiter heredoc detection).
+
+---
+
+### Task 1: Stripper helper + unit tests
+
+**Files:**
+- Create: `hooks/tests/command-match.test.sh`
+- Create: `hooks/scripts/lib/command-match.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Write `hooks/tests/command-match.test.sh` with exactly this content:
+
+```bash
+#!/usr/bin/env bash
+# command-match.test.sh — table-driven tests for
+# strip_quoted_segments (#450).
+#
+# Encodes the stripping-relevant vectors of the canonical case
+# table: docs/specs/2026-06-05-450-command-matcher-quoting-design.md
+# §6.1 (rows 5, 7–10, 14) plus the empty command. bash
+# 3.2-compatible: parallel indexed arrays.
+#
+# Usage: bash hooks/tests/command-match.test.sh
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../scripts/lib/command-match.sh"
+
+NL='
+'
+
+T_NAME=(
+  "row 5: multi-line quoted body (#450 repro)"
+  "row 7: double-quoted span"
+  "row 8: single quotes nesting double quotes"
+  "row 9: escaped double quotes inside a span"
+  "row 10: unbalanced quote stays unstripped (separator in span)"
+  "row 14: unbalanced quote stays unstripped (no separator)"
+  "empty command"
+)
+T_INPUT=(
+  "vrg-commit --body \"line one${NL}git commit mentioned here\""
+  'echo "git commit"'
+  "echo 'say \"git commit\"'"
+  'echo "he said \"git commit\""'
+  'echo "; git commit'
+  'echo "git commit'
+  ""
+)
+T_EXPECT=(
+  'vrg-commit --body ""'
+  'echo ""'
+  'echo ""'
+  'echo ""'
+  'echo "; git commit'
+  'echo "git commit'
+  ""
+)
+
+pass=0
+fail=0
+i=0
+total=${#T_NAME[@]}
+
+while [ "$i" -lt "$total" ]; do
+  name="${T_NAME[$i]}"
+  got=$(strip_quoted_segments "${T_INPUT[$i]}")
+  expect="${T_EXPECT[$i]}"
+
+  if [ "$got" = "$expect" ]; then
+    echo "PASS [$i] $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL [$i] $name"
+    printf '       expected: %s\n' "$expect"
+    printf '       got:      %s\n' "$got"
+    fail=$((fail + 1))
+  fi
+  i=$((i + 1))
+done
+
+echo "----------------------------------------"
+echo "command-match: $pass passed, $fail failed, $total total"
+[ "$fail" -eq 0 ]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from the worktree root):
+`bash hooks/tests/command-match.test.sh`
+Expected: a source error
+(`…/lib/command-match.sh: No such file or directory`), then every
+case FAILs with `strip_quoted_segments: command not found` noise,
+and the suite exits non-zero. (The suite uses `set -u`, not
+`set -e`, so the failed `source` does not abort the run.)
+
+- [ ] **Step 3: Commit the red test**
+
+```bash
+vrg-git add hooks/tests/command-match.test.sh
+vrg-commit --type test --scope hooks \
+  --message "add failing stripper tests for command matchers" \
+  --body "Table-driven tests for strip_quoted_segments encoding the stripping-relevant canonical vectors from spec section 6.1 (rows 5, 7-10, 14) plus the empty command. RED: the lib does not exist yet. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+- [ ] **Step 4: Write the implementation**
+
+Write `hooks/scripts/lib/command-match.sh` with exactly this content
+(tabs for indentation, matching `managed-repo-check.sh`):
+
+```bash
+#!/usr/bin/env bash
+# command-match.sh — shared quote-stripping helper for the plugin's
+# command matchers (#450).
+#
+# Tool-name matchers scan the Bash tool's raw command string. A tool
+# name at the start of a line inside a quoted multi-line argument
+# (vrg-commit --body, vrg-gh issue create --body) is
+# indistinguishable from a tool name in command position, producing
+# false denies. Stripping quoted spans first removes argument
+# content from the matcher's view; what remains is command
+# structure.
+#
+# Canonical rule and accepted gaps:
+#   docs/specs/2026-06-05-450-command-matcher-quoting-design.md §2
+#
+# This file is meant to be `source`d, not executed directly.
+#
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/command-match.sh"
+#   stripped=$(strip_quoted_segments "$command")
+#   if echo "$stripped" | grep -qE '(^|[;&|({]\s*)git\s+commit(\s|$)'; then
+
+# strip_quoted_segments <command-text>
+#
+# Prints the command text with single- and double-quoted spans
+# replaced by the placeholder "" in one left-to-right pass (leftmost
+# match wins, mirroring how the shell scans). Double-quoted spans
+# honor backslash escapes; single-quoted spans do not (shell
+# semantics). Multi-line spans are handled: jq's gsub operates on
+# the whole string, unlike line-oriented sed/grep. jq is already a
+# hard dependency of every hook script.
+#
+# Unbalanced quotes leave the remainder unstripped — a
+# false-positive (over-blocking) direction only; see spec §2.1.
+strip_quoted_segments() {
+	printf '%s' "$1" | jq -Rsr 'gsub("\"(\\\\.|[^\"\\\\])*\"|'\''[^'\'']*'\''"; "\"\"")'
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bash hooks/tests/command-match.test.sh`
+Expected: `command-match: 7 passed, 0 failed, 7 total`, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+vrg-git add hooks/scripts/lib/command-match.sh
+vrg-commit --type feat --scope hooks \
+  --message "add shared quote-stripping helper for command matchers" \
+  --body "strip_quoted_segments replaces quoted spans with a placeholder in one leftmost-wins jq gsub pass, multi-line aware, escape-aware for double quotes. Single seam for the false-positive fix; spec section 3.1. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 2: Matcher test harness + `block-raw-git-commit.sh`
+
+**Files:**
+- Create: `hooks/tests/command-matchers.test.sh`
+- Modify: `hooks/scripts/block-raw-git-commit.sh`
+
+- [ ] **Step 1: Write the failing harness**
+
+Write `hooks/tests/command-matchers.test.sh` with exactly this
+content. It encodes the canonical table rows 1–10, 13, 14 against
+`block-raw-git-commit.sh` (rows 11–12 are vrg-hook-guard-only);
+later tasks append per-script rows to the same arrays.
+
+```bash
+#!/usr/bin/env bash
+# command-matchers.test.sh — table-driven allow/deny tests for the
+# hook command matchers (#450).
+#
+# Encodes the canonical case table from
+# docs/specs/2026-06-05-450-command-matcher-quoting-design.md §6.1
+# (rows 11-12 excluded: the bash -c recheck lives in vrg-hook-guard,
+# not the plugin scripts), plus per-script cases. bash
+# 3.2-compatible: parallel indexed arrays.
+#
+# Usage: bash hooks/tests/command-matchers.test.sh
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$SCRIPT_DIR/../scripts"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+NL='
+'
+
+# block-raw-git-commit.sh delegates to vrg-hook-guard when it is on
+# PATH; mask it so the fallback regex path is what's tested.
+CLEAN_PATH=""
+old_ifs="$IFS"
+IFS=':'
+for dir in $PATH; do
+  if [ -x "$dir/vrg-hook-guard" ]; then
+    continue
+  fi
+  CLEAN_PATH="${CLEAN_PATH:+$CLEAN_PATH:}$dir"
+done
+IFS="$old_ifs"
+
+# Scratch managed repo that has adopted the worktree convention, for
+# block-protected-branch-work.sh rows. Using a scratch repo keeps
+# those rows deterministic whether this suite runs from the main
+# checkout or from inside a worktree.
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+git -C "$SCRATCH" init --quiet
+printf '[project]\n' > "$SCRATCH/vergil.toml"
+printf '.worktrees/\n' > "$SCRATCH/.gitignore"
+
+# Parallel arrays: one case per index.
+#   T_NAME     — label
+#   T_SCRIPT   — hook script under hooks/scripts/
+#   T_COMMAND  — tool_input.command payload value
+#   T_CWD      — payload cwd: "" = $ROOT, "SCRATCH" = $SCRATCH
+#   T_RESPONSE — tool_response payload value ("" = omit)
+#   T_EXPECT   — deny | allow | context
+T_NAME=(
+  "rgc row 1: plain invocation"
+  "rgc row 2: separator"
+  "rgc row 3: subshell separator"
+  "rgc row 4: brace-group separator"
+  "rgc row 5: multi-line quoted body (#450 repro)"
+  "rgc row 6: dot-git path"
+  "rgc row 7: double-quoted span"
+  "rgc row 8: single quotes nesting double quotes"
+  "rgc row 9: escaped double quotes"
+  "rgc row 10: unbalanced quote, separator in span (accepted FP)"
+  "rgc row 13: keyword position (accepted FN gap)"
+  "rgc row 14: unbalanced quote, no separator"
+)
+T_SCRIPT=(
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+)
+T_COMMAND=(
+  'git commit -m x'
+  'cd foo && git commit'
+  'x=$(git commit -m x)'
+  '{ git commit -m x; }'
+  "vrg-commit --type docs --scope x --message y --body \"line one${NL}git commit mentioned here\""
+  'find . -path ./.git -prune'
+  'echo "git commit"'
+  "echo 'say \"git commit\"'"
+  'echo "he said \"git commit\""'
+  'echo "; git commit'
+  'if git commit; then :; fi'
+  'echo "git commit'
+)
+T_CWD=(
+  "" "" "" "" "" "" "" "" "" "" "" ""
+)
+T_RESPONSE=(
+  "" "" "" "" "" "" "" "" "" "" "" ""
+)
+T_EXPECT=(
+  "deny"
+  "deny"
+  "deny"
+  "deny"
+  "allow"
+  "allow"
+  "allow"
+  "allow"
+  "allow"
+  "deny"
+  "allow"
+  "allow"
+)
+
+pass=0
+fail=0
+i=0
+total=${#T_NAME[@]}
+
+while [ "$i" -lt "$total" ]; do
+  name="${T_NAME[$i]}"
+  script="${T_SCRIPT[$i]}"
+  cmd="${T_COMMAND[$i]}"
+  case_cwd="${T_CWD[$i]}"
+  resp="${T_RESPONSE[$i]}"
+  expect="${T_EXPECT[$i]}"
+
+  if [ "$case_cwd" = "SCRATCH" ]; then
+    case_cwd="$SCRATCH"
+  elif [ -z "$case_cwd" ]; then
+    case_cwd="$ROOT"
+  fi
+
+  payload=$(jq -n --arg cmd "$cmd" --arg cwd "$case_cwd" --arg resp "$resp" \
+    '{tool_input: {command: $cmd, cwd: $cwd}, cwd: $cwd}
+     + (if $resp == "" then {} else {tool_response: $resp} end)')
+
+  out=$(printf '%s' "$payload" \
+    | PATH="$CLEAN_PATH" bash "$SCRIPTS/$script" 2>&1) || true
+
+  verdict="allow"
+  if printf '%s' "$out" | grep -q '"permissionDecision": "deny"'; then
+    verdict="deny"
+  elif printf '%s' "$out" | grep -q '"additionalContext"'; then
+    verdict="context"
+  elif [ -n "$out" ]; then
+    # Any other output (errors, partial JSON) is a test failure.
+    verdict="error"
+  fi
+
+  if [ "$verdict" = "$expect" ]; then
+    echo "PASS [$i] $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL [$i] $name — expected $expect, got $verdict"
+    if [ -n "$out" ]; then
+      printf '%s\n' "$out" | head -5 | sed 's/^/       /'
+    fi
+    fail=$((fail + 1))
+  fi
+  i=$((i + 1))
+done
+
+echo "----------------------------------------"
+echo "command-matchers: $pass passed, $fail failed, $total total"
+[ "$fail" -eq 0 ]
+```
+
+- [ ] **Step 2: Run to verify the expected failures**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: exactly 3 FAILs —
+- `[2] rgc row 3` (subshell — `(` not yet a separator → got allow)
+- `[3] rgc row 4` (brace group — `{` not yet a separator → got allow)
+- `[4] rgc row 5` (#450 repro — quoted body still matched → got deny)
+
+All other rows PASS. If a different set fails, stop and debug
+before proceeding.
+
+- [ ] **Step 3: Commit the red harness**
+
+```bash
+vrg-git add hooks/tests/command-matchers.test.sh
+vrg-commit --type test --scope hooks \
+  --message "add failing matcher tests encoding the canonical case table" \
+  --body "Allow/deny harness feeding hook JSON to the matcher scripts, starting with the spec section 6.1 table against block-raw-git-commit (rows 11-12 excluded as vrg-hook-guard-only). RED: rows 3, 4, 5 fail until the script is migrated. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+- [ ] **Step 4: Migrate `block-raw-git-commit.sh`**
+
+In `hooks/scripts/block-raw-git-commit.sh`, make two edits.
+
+Edit A — source the helper (after the existing
+`managed-repo-check.sh` source):
+
+```bash
+# old
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+```
+
+```bash
+# new
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
+```
+
+Edit B — match against stripped text with the hardened anchor:
+
+```bash
+# old
+command=$(echo "$input" | jq -r '.tool_input.command')
+
+if echo "$command" | grep -qE '(^|[;&|]\s*)git\s+commit(\s|$)'; then
+```
+
+```bash
+# new
+command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
+
+if echo "$stripped" | grep -qE '(^|[;&|({]\s*)git\s+commit(\s|$)'; then
+```
+
+- [ ] **Step 5: Run to verify green**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: `command-matchers: 12 passed, 0 failed, 12 total`, exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+vrg-git add hooks/scripts/block-raw-git-commit.sh
+vrg-commit --type fix --scope hooks \
+  --message "match raw-git-commit fallback against quote-stripped text" \
+  --body "The fallback regex now runs on strip_quoted_segments output with the hardened anchor, so tool names at line start inside quoted multi-line arguments no longer deny legitimate commands. Spec section 3.2. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 3: `block-raw-gh-pr-create.sh`
+
+**Files:**
+- Modify: `hooks/tests/command-matchers.test.sh` (append rows)
+- Modify: `hooks/scripts/block-raw-gh-pr-create.sh`
+
+- [ ] **Step 1: Append failing rows**
+
+Append to the END of each array in
+`hooks/tests/command-matchers.test.sh` (keep array positions aligned
+across all six arrays; same pattern in every later task):
+
+To `T_NAME`:
+
+```bash
+  "pr-create: plain invocation"
+  "pr-create: quoted body prose (#450 shape)"
+  "pr-create: gh api POST to /pulls"
+```
+
+To `T_SCRIPT`:
+
+```bash
+  "block-raw-gh-pr-create.sh"
+  "block-raw-gh-pr-create.sh"
+  "block-raw-gh-pr-create.sh"
+```
+
+To `T_COMMAND`:
+
+```bash
+  'gh pr create --title x'
+  "vrg-commit --type docs --scope x --message y --body \"docs say${NL}gh pr create is blocked\""
+  'gh api repos/o/r/pulls -X POST'
+```
+
+To `T_CWD`:
+
+```bash
+  "" "" ""
+```
+
+To `T_RESPONSE`:
+
+```bash
+  "" "" ""
+```
+
+To `T_EXPECT`:
+
+```bash
+  "deny"
+  "allow"
+  "deny"
+```
+
+- [ ] **Step 2: Run to verify the expected failure**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: exactly 1 FAIL — `pr-create: quoted body prose` (got deny).
+
+- [ ] **Step 3: Migrate the script**
+
+In `hooks/scripts/block-raw-gh-pr-create.sh`:
+
+Edit A — source the helper:
+
+```bash
+# old
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+```
+
+```bash
+# new
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
+```
+
+Edit B — compute stripped text and point the two tool-name
+predicates at it (the HTTP-method check stays on `$command`, spec
+§2.3):
+
+```bash
+# old
+command=$(echo "$input" | jq -r '.tool_input.command')
+```
+
+```bash
+# new
+command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
+```
+
+Edit C:
+
+```bash
+# old
+if echo "$command" | grep -qE '(^|[;&|]\s*)gh\s+pr\s+create(\s|$)'; then
+```
+
+```bash
+# new
+if echo "$stripped" | grep -qE '(^|[;&|({]\s*)gh\s+pr\s+create(\s|$)'; then
+```
+
+Edit D:
+
+```bash
+# old
+elif echo "$command" | grep -qE 'gh\s+api\s+.*(/pulls)(\s|$)' \
+```
+
+```bash
+# new
+elif echo "$stripped" | grep -qE 'gh\s+api\s+.*(/pulls)(\s|$)' \
+```
+
+(The following line — `grep -qiE '(-X\s+POST|--method\s+POST|-XPOST)'`
+on `$command` — is intentionally unchanged.)
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: `command-matchers: 15 passed, 0 failed, 15 total`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add hooks/scripts/block-raw-gh-pr-create.sh hooks/tests/command-matchers.test.sh
+vrg-commit --type fix --scope hooks \
+  --message "match pr-create tool-name predicates against stripped text" \
+  --body "Both invocation predicates now run on quote-stripped text with the hardened anchor; the HTTP-method flag check stays on raw text per spec section 2.3. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 4: `block-agent-merge.sh`
+
+**Files:**
+- Modify: `hooks/tests/command-matchers.test.sh` (append rows)
+- Modify: `hooks/scripts/block-agent-merge.sh`
+
+- [ ] **Step 1: Append failing rows**
+
+Append (same array-alignment rule):
+
+To `T_NAME`:
+
+```bash
+  "agent-merge: gh pr merge"
+  "agent-merge: gh pr review --approve"
+  "agent-merge: quoted body prose (#450 shape)"
+  "agent-merge: gh api PUT merge"
+```
+
+To `T_SCRIPT`:
+
+```bash
+  "block-agent-merge.sh"
+  "block-agent-merge.sh"
+  "block-agent-merge.sh"
+  "block-agent-merge.sh"
+```
+
+To `T_COMMAND`:
+
+```bash
+  'gh pr merge 5'
+  'gh pr review 5 --approve'
+  "vrg-gh issue create --title t --body \"policy:${NL}gh pr merge 5 is forbidden\""
+  'gh api repos/o/r/pulls/5/merge -X PUT'
+```
+
+To `T_CWD`:
+
+```bash
+  "" "" "" ""
+```
+
+To `T_RESPONSE`:
+
+```bash
+  "" "" "" ""
+```
+
+To `T_EXPECT`:
+
+```bash
+  "deny"
+  "deny"
+  "allow"
+  "deny"
+```
+
+- [ ] **Step 2: Run to verify the expected failure**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: exactly 1 FAIL — `agent-merge: quoted body prose`
+(got deny).
+
+- [ ] **Step 3: Migrate the script**
+
+In `hooks/scripts/block-agent-merge.sh`:
+
+Edit A — source the helper:
+
+```bash
+# old
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+```
+
+```bash
+# new
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
+```
+
+Edit B:
+
+```bash
+# old
+command=$(echo "$input" | jq -r '.tool_input.command')
+```
+
+```bash
+# new
+command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
+```
+
+Edit C — the three tool-name predicates move to `$stripped`; the
+case-insensitive method-flag greps stay on `$command` (spec §2.3):
+
+```bash
+# old
+if echo "$command" \
+     | grep -qE '(^|[;&|]\s*)gh\s+pr\s+(merge(\s|$)|review\s+.*--approve)'; then
+  is_merge_command=true
+fi
+
+if echo "$command" | grep -qE 'gh\s+api\s+.*/pulls/[0-9]+/merge(\s|$)' \
+  && echo "$command" | grep -qiE '(-X\s+PUT|--method\s+PUT|-XPUT)'; then
+  is_merge_command=true
+fi
+
+if echo "$command" | grep -qE 'gh\s+api\s+.*/pulls/[0-9]+/reviews(\s|$)' \
+  && echo "$command" | grep -qiE '(-X\s+POST|--method\s+POST|-XPOST)'; then
+  is_merge_command=true
+fi
+```
+
+```bash
+# new
+if echo "$stripped" \
+     | grep -qE '(^|[;&|({]\s*)gh\s+pr\s+(merge(\s|$)|review\s+.*--approve)'; then
+  is_merge_command=true
+fi
+
+if echo "$stripped" | grep -qE 'gh\s+api\s+.*/pulls/[0-9]+/merge(\s|$)' \
+  && echo "$command" | grep -qiE '(-X\s+PUT|--method\s+PUT|-XPUT)'; then
+  is_merge_command=true
+fi
+
+if echo "$stripped" | grep -qE 'gh\s+api\s+.*/pulls/[0-9]+/reviews(\s|$)' \
+  && echo "$command" | grep -qiE '(-X\s+POST|--method\s+POST|-XPOST)'; then
+  is_merge_command=true
+fi
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: `command-matchers: 19 passed, 0 failed, 19 total`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add hooks/scripts/block-agent-merge.sh hooks/tests/command-matchers.test.sh
+vrg-commit --type fix --scope hooks \
+  --message "match agent-merge tool-name predicates against stripped text" \
+  --body "All three merge/approve invocation predicates now run on quote-stripped text with the hardened anchor; method-flag greps stay on raw text per spec section 2.3. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 5: `enforce-host-container-split.sh`
+
+**Files:**
+- Modify: `hooks/tests/command-matchers.test.sh` (append rows)
+- Modify: `hooks/scripts/enforce-host-container-split.sh`
+
+- [ ] **Step 1: Append failing rows**
+
+To `T_NAME`:
+
+```bash
+  "host-split: wrapped host tool denied"
+  "host-split: quoted body mentioning wrapped host tool (#450 shape)"
+  "host-split: bare container tool warns"
+  "host-split: quoted body mentioning container tool (#450 shape)"
+```
+
+To `T_SCRIPT`:
+
+```bash
+  "enforce-host-container-split.sh"
+  "enforce-host-container-split.sh"
+  "enforce-host-container-split.sh"
+  "enforce-host-container-split.sh"
+```
+
+To `T_COMMAND`:
+
+```bash
+  'vrg-container-run -- git status'
+  "vrg-commit --type docs --scope x --message y --body \"never do this:${NL}vrg-container-run -- gh pr list\""
+  'shellcheck hooks/scripts/lib/command-match.sh'
+  "vrg-commit --type docs --scope x --message y --body \"container tools:${NL}shellcheck runs in the container\""
+```
+
+To `T_CWD`:
+
+```bash
+  "" "" "" ""
+```
+
+To `T_RESPONSE`:
+
+```bash
+  "" "" "" ""
+```
+
+To `T_EXPECT`:
+
+```bash
+  "deny"
+  "allow"
+  "context"
+  "allow"
+```
+
+- [ ] **Step 2: Run to verify the expected failures**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: exactly 2 FAILs — both `#450 shape` rows (got deny and
+context respectively).
+
+- [ ] **Step 3: Migrate the script**
+
+In `hooks/scripts/enforce-host-container-split.sh`:
+
+Edit A — source the helper (this script sources two libs already;
+add after them):
+
+```bash
+# old
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/host-container-tools.sh"
+```
+
+```bash
+# new
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/host-container-tools.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
+```
+
+Edit B:
+
+```bash
+# old
+command=$(echo "$input" | jq -r '.tool_input.command')
+```
+
+```bash
+# new
+command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
+```
+
+Edit C — DENY loop:
+
+```bash
+# old
+  if echo "$command" | grep -qE "(^|[;&|]\s*)vrg-container-run\s+--\s+$tool(\s|$)"; then
+```
+
+```bash
+# new
+  if echo "$stripped" | grep -qE "(^|[;&|({]\s*)vrg-container-run\s+--\s+$tool(\s|$)"; then
+```
+
+Edit D — WARN loop:
+
+```bash
+# old
+  if echo "$command" | grep -qE "(^|[;&|]\s*)(vrg-container-run\s+--\s+)?$tool(\s|$)"; then
+```
+
+```bash
+# new
+  if echo "$stripped" | grep -qE "(^|[;&|({]\s*)(vrg-container-run\s+--\s+)?$tool(\s|$)"; then
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: `command-matchers: 23 passed, 0 failed, 23 total`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add hooks/scripts/enforce-host-container-split.sh hooks/tests/command-matchers.test.sh
+vrg-commit --type fix --scope hooks \
+  --message "match host-container-split loops against stripped text" \
+  --body "Both routing loops now run on quote-stripped text with the hardened anchor, so tool names mentioned in quoted prose no longer deny or warn. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 6: `detect-deprecation-warnings.sh`
+
+**Files:**
+- Modify: `hooks/tests/command-matchers.test.sh` (append rows)
+- Modify: `hooks/scripts/detect-deprecation-warnings.sh`
+
+- [ ] **Step 1: Append failing rows**
+
+To `T_NAME`:
+
+```bash
+  "deprecation: pytest with warning in output"
+  "deprecation: quoted body mentioning pytest (#450 shape)"
+  "deprecation: pytest with clean output"
+```
+
+To `T_SCRIPT`:
+
+```bash
+  "detect-deprecation-warnings.sh"
+  "detect-deprecation-warnings.sh"
+  "detect-deprecation-warnings.sh"
+```
+
+To `T_COMMAND`:
+
+```bash
+  'pytest -q'
+  "vrg-commit --type docs --scope x --message y --body \"test notes:${NL}pytest emitted warnings\""
+  'pytest -q'
+```
+
+To `T_CWD`:
+
+```bash
+  "" "" ""
+```
+
+To `T_RESPONSE`:
+
+```bash
+  "DeprecationWarning: old API"
+  "DeprecationWarning: old API"
+  "2 passed"
+```
+
+To `T_EXPECT`:
+
+```bash
+  "context"
+  "allow"
+  "allow"
+```
+
+- [ ] **Step 2: Run to verify the expected failure**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: exactly 1 FAIL — `deprecation: quoted body mentioning
+pytest` (got context).
+
+- [ ] **Step 3: Migrate the script**
+
+In `hooks/scripts/detect-deprecation-warnings.sh`:
+
+Edit A — source the helper:
+
+```bash
+# old
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+```
+
+```bash
+# new
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
+```
+
+Edit B — the command matcher moves to stripped text; the
+`tool_response` scan is output, not a command, and is intentionally
+unchanged:
+
+```bash
+# old
+command=$(echo "$input" | jq -r '.tool_input.command')
+response=$(echo "$input" | jq -r '.tool_response // ""')
+
+# Only trigger after test commands
+is_test_command=false
+if echo "$command" | grep -qE '(^|[;&|]\s*)(pytest|cargo\s+test|go\s+test|bundle\s+exec\s+rspec|ruby\s+-e|rake\s+test|mvn\s+test|uv\s+run\s+pytest)(\s|$)'; then
+```
+
+```bash
+# new
+command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
+response=$(echo "$input" | jq -r '.tool_response // ""')
+
+# Only trigger after test commands
+is_test_command=false
+if echo "$stripped" | grep -qE '(^|[;&|({]\s*)(pytest|cargo\s+test|go\s+test|bundle\s+exec\s+rspec|ruby\s+-e|rake\s+test|mvn\s+test|uv\s+run\s+pytest)(\s|$)'; then
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: `command-matchers: 26 passed, 0 failed, 26 total`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add hooks/scripts/detect-deprecation-warnings.sh hooks/tests/command-matchers.test.sh
+vrg-commit --type fix --scope hooks \
+  --message "match deprecation test-command predicate against stripped text" \
+  --body "The test-runner matcher now runs on quote-stripped text with the hardened anchor; the deprecation scan of tool output is unchanged. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 7: `block-protected-branch-work.sh`
+
+**Files:**
+- Modify: `hooks/tests/command-matchers.test.sh` (append rows)
+- Modify: `hooks/scripts/block-protected-branch-work.sh`
+
+- [ ] **Step 1: Append failing rows**
+
+These rows use the scratch repo (`T_CWD` = `SCRATCH`), whose root is
+outside `.worktrees/` and whose `.gitignore` adopts the convention,
+so commits from its root are denied.
+
+To `T_NAME`:
+
+```bash
+  "protected: real commit at convention-repo root"
+  "protected: non-commit with quoted commit prose (#450 over-blocking)"
+  "protected: non-commit git operation"
+```
+
+To `T_SCRIPT`:
+
+```bash
+  "block-protected-branch-work.sh"
+  "block-protected-branch-work.sh"
+  "block-protected-branch-work.sh"
+```
+
+To `T_COMMAND`:
+
+```bash
+  'git commit -m x'
+  "vrg-gh issue create --title t --body \"repro:${NL}git commit -m x was blocked\""
+  'git push origin HEAD'
+```
+
+To `T_CWD`:
+
+```bash
+  "SCRATCH" "SCRATCH" "SCRATCH"
+```
+
+To `T_RESPONSE`:
+
+```bash
+  "" "" ""
+```
+
+To `T_EXPECT`:
+
+```bash
+  "deny"
+  "allow"
+  "allow"
+```
+
+- [ ] **Step 2: Run to verify the expected failure**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: exactly 1 FAIL — `protected: non-commit with quoted commit
+prose` (got deny — the over-blocking direction from spec §3.2).
+
+- [ ] **Step 3: Migrate the script**
+
+In `hooks/scripts/block-protected-branch-work.sh`:
+
+Edit A — source the helper:
+
+```bash
+# old
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+```
+
+```bash
+# new
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
+```
+
+Edit B — the gating matcher moves to stripped text. The `cd` /
+`git -C` directory-extraction greps further down stay on
+`$command` — they extract paths, which are legitimately quoted
+(spec §2.3):
+
+```bash
+# old
+command=$(echo "$input" | jq -r '.tool_input.command')
+
+# Only check commands that could create commits on the current branch.
+# Allow git operations that don't create commits (checkout, push, pull, etc.).
+if ! echo "$command" | grep -qE '(^|[;&|]\s*)(git\s+commit|vrg-commit)(\s|$)'; then
+  exit 0
+fi
+```
+
+```bash
+# new
+command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
+
+# Only check commands that could create commits on the current branch.
+# Allow git operations that don't create commits (checkout, push, pull, etc.).
+if ! echo "$stripped" | grep -qE '(^|[;&|({]\s*)(git\s+commit|vrg-commit)(\s|$)'; then
+  exit 0
+fi
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: `command-matchers: 29 passed, 0 failed, 29 total`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add hooks/scripts/block-protected-branch-work.sh hooks/tests/command-matchers.test.sh
+vrg-commit --type fix --scope hooks \
+  --message "match protected-branch gating predicate against stripped text" \
+  --body "The commit-detection gate now runs on quote-stripped text with the hardened anchor, so non-commit commands with commit-looking quoted prose are no longer subjected to the worktree check. Directory-extraction greps stay on raw text per spec section 2.3. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 8: `block-autoclose-linkage.sh`
+
+**Files:**
+- Modify: `hooks/tests/command-matchers.test.sh` (append rows)
+- Modify: `hooks/scripts/block-autoclose-linkage.sh`
+
+- [ ] **Step 1: Append failing rows**
+
+To `T_NAME`:
+
+```bash
+  "autoclose: forbidden linkage keyword"
+  "autoclose: Ref linkage allowed"
+  "autoclose: quoted body mentioning the rule (#450 shape)"
+```
+
+To `T_SCRIPT`:
+
+```bash
+  "block-autoclose-linkage.sh"
+  "block-autoclose-linkage.sh"
+  "block-autoclose-linkage.sh"
+```
+
+To `T_COMMAND`:
+
+```bash
+  'vrg-submit-pr --issue 450 --linkage Fixes'
+  'vrg-submit-pr --issue 450 --linkage Ref'
+  "vrg-commit --type docs --scope x --message y --body \"policy reminder:${NL}vrg-submit-pr --linkage Fixes is forbidden\""
+```
+
+To `T_CWD`:
+
+```bash
+  "" "" ""
+```
+
+To `T_RESPONSE`:
+
+```bash
+  "" "" ""
+```
+
+To `T_EXPECT`:
+
+```bash
+  "deny"
+  "allow"
+  "allow"
+```
+
+- [ ] **Step 2: Run to verify the expected failure**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: exactly 1 FAIL — `autoclose: quoted body mentioning the
+rule` (got deny — the loose `\b` matcher hits prose).
+
+- [ ] **Step 3: Migrate the script**
+
+In `hooks/scripts/block-autoclose-linkage.sh`:
+
+Edit A — source the helper:
+
+```bash
+# old
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+```
+
+```bash
+# new
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
+```
+
+Edit B — the loose `\b` matcher becomes the canonical anchor on
+stripped text; the `--linkage` value check stays on `$command`
+(spec §3.2):
+
+```bash
+# old
+command=$(echo "$input" | jq -r '.tool_input.command')
+
+if echo "$command" | grep -qE 'vrg-submit-pr\b'; then
+```
+
+```bash
+# new
+command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
+
+if echo "$stripped" | grep -qE '(^|[;&|({]\s*)vrg-submit-pr(\s|$)'; then
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: `command-matchers: 32 passed, 0 failed, 32 total`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add hooks/scripts/block-autoclose-linkage.sh hooks/tests/command-matchers.test.sh
+vrg-commit --type fix --scope hooks \
+  --message "anchor autoclose-linkage tool predicate on stripped text" \
+  --body "Replaces the loose word-boundary match with the canonical command-position anchor on quote-stripped text; the linkage-value check stays on raw text. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 9: `block-github-contents-api.sh`
+
+**Files:**
+- Modify: `hooks/tests/command-matchers.test.sh` (append rows)
+- Modify: `hooks/scripts/block-github-contents-api.sh`
+
+- [ ] **Step 1: Append failing rows**
+
+To `T_NAME`:
+
+```bash
+  "contents-api: write method denied"
+  "contents-api: GET allowed"
+  "contents-api: quoted body citing the blocked call (#450 shape)"
+```
+
+To `T_SCRIPT`:
+
+```bash
+  "block-github-contents-api.sh"
+  "block-github-contents-api.sh"
+  "block-github-contents-api.sh"
+```
+
+To `T_COMMAND`:
+
+```bash
+  'gh api --method PUT repos/o/r/contents/f.md'
+  'gh api repos/o/r/contents/f.md'
+  "vrg-commit --type docs --scope x --message y --body \"blocked example:${NL}gh api --method PUT repos/o/r/contents/f.md\""
+```
+
+To `T_CWD`:
+
+```bash
+  "" "" ""
+```
+
+To `T_RESPONSE`:
+
+```bash
+  "" "" ""
+```
+
+To `T_EXPECT`:
+
+```bash
+  "deny"
+  "allow"
+  "allow"
+```
+
+- [ ] **Step 2: Run to verify the expected failure**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: exactly 1 FAIL — `contents-api: quoted body citing the
+blocked call` (got deny).
+
+- [ ] **Step 3: Migrate the script**
+
+In `hooks/scripts/block-github-contents-api.sh`:
+
+Edit A — source the helper:
+
+```bash
+# old
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+```
+
+```bash
+# new
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
+```
+
+Edit B — only the `gh api` invocation detection moves to stripped
+text. The contents-URL grep and the method grep stay on `$command`:
+URLs and flags are legitimately quoted arguments (spec §2.3, §3.2):
+
+```bash
+# old
+command=$(echo "$input" | jq -r '.tool_input.command')
+```
+
+```bash
+# new
+command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
+```
+
+Edit C:
+
+```bash
+# old
+if echo "$command" | grep -qE 'gh\s+api\s' && echo "$command" | grep -qE '(repos/[^[:space:]]*/contents/|https://api\.github\.com/repos/[^[:space:]]*/contents/)'; then
+```
+
+```bash
+# new
+if echo "$stripped" | grep -qE 'gh\s+api\s' && echo "$command" | grep -qE '(repos/[^[:space:]]*/contents/|https://api\.github\.com/repos/[^[:space:]]*/contents/)'; then
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: `command-matchers: 35 passed, 0 failed, 35 total`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add hooks/scripts/block-github-contents-api.sh hooks/tests/command-matchers.test.sh
+vrg-commit --type fix --scope hooks \
+  --message "match contents-api invocation detection against stripped text" \
+  --body "Only the api-invocation predicate moves to quote-stripped text; the contents-URL and method greps stay on raw text because those targets are legitimately quoted arguments. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 10: `block-associative-arrays.sh`
+
+**Files:**
+- Modify: `hooks/tests/command-matchers.test.sh` (append rows)
+- Modify: `hooks/scripts/block-associative-arrays.sh`
+
+- [ ] **Step 1: Append failing rows**
+
+To `T_NAME`:
+
+```bash
+  "assoc: declare -A denied"
+  "assoc: indexed array allowed"
+  "assoc: quoted body citing the rule (#450 shape)"
+```
+
+To `T_SCRIPT`:
+
+```bash
+  "block-associative-arrays.sh"
+  "block-associative-arrays.sh"
+  "block-associative-arrays.sh"
+```
+
+To `T_COMMAND`:
+
+```bash
+  'declare -A map'
+  'declare -a list'
+  "vrg-commit --type docs --scope x --message y --body \"bash policy:${NL}declare -A needs bash 4 and is blocked\""
+```
+
+To `T_CWD`:
+
+```bash
+  "" "" ""
+```
+
+To `T_RESPONSE`:
+
+```bash
+  "" "" ""
+```
+
+To `T_EXPECT`:
+
+```bash
+  "deny"
+  "allow"
+  "allow"
+```
+
+- [ ] **Step 2: Run to verify the expected failure**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: exactly 1 FAIL — `assoc: quoted body citing the rule`
+(got deny).
+
+- [ ] **Step 3: Migrate the script**
+
+In `hooks/scripts/block-associative-arrays.sh`:
+
+Edit A — source the helper:
+
+```bash
+# old
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+```
+
+```bash
+# new
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
+```
+
+Edit B — this matcher keeps its existing regex shape (it
+deliberately matches `declare` in any position, since `declare` is
+valid mid-pipeline); only the text it scans changes:
+
+```bash
+# old
+command=$(echo "$input" | jq -r '.tool_input.command')
+
+# Match declare with -A flag in any position (e.g., -A, -Ag, -rA, -gA).
+if echo "$command" | grep -qE 'declare\s+-[a-zA-Z]*A'; then
+```
+
+```bash
+# new
+command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
+
+# Match declare with -A flag in any position (e.g., -A, -Ag, -rA, -gA).
+if echo "$stripped" | grep -qE 'declare\s+-[a-zA-Z]*A'; then
+```
+
+- [ ] **Step 4: Run to verify green**
+
+Run: `bash hooks/tests/command-matchers.test.sh`
+Expected: `command-matchers: 38 passed, 0 failed, 38 total`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vrg-git add hooks/scripts/block-associative-arrays.sh hooks/tests/command-matchers.test.sh
+vrg-commit --type fix --scope hooks \
+  --message "match associative-array predicate against stripped text" \
+  --body "Prose about declare -A inside quoted arguments no longer denies the command; the regex shape is unchanged. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 11: Wire hook tests into validation
+
+**Files:**
+- Create: `scripts/bin/validate-custom`
+
+- [ ] **Step 1: Write the custom validator**
+
+Write `scripts/bin/validate-custom` with exactly this content
+(`vrg-validate` discovers and runs this path; spec §6.5):
+
+```bash
+#!/usr/bin/env bash
+# validate-custom — repo-local validation hook discovered by
+# vrg-validate. Runs the hook test suites under hooks/tests/.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+status=0
+for t in "$ROOT"/hooks/tests/*.test.sh; do
+	echo "Running: $t"
+	bash "$t" || status=1
+done
+exit "$status"
+```
+
+- [ ] **Step 2: Make it executable and verify it runs both suites**
+
+```bash
+chmod +x scripts/bin/validate-custom
+bash scripts/bin/validate-custom
+```
+
+Expected: all three suites run (`command-match`,
+`command-matchers`, `guard-audit-writes`), all green, exit 0.
+
+- [ ] **Step 3: Run full validation**
+
+```bash
+vrg-container-run -- vrg-validate
+```
+
+Expected: exit 0, with the custom validator's output included. If
+shellcheck flags the new files, fix the findings before committing
+(do not suppress). If the container image lacks `jq` or `git` (the
+test suites need both), stop and surface that to the human — do not
+work around it by skipping suites.
+
+- [ ] **Step 4: Commit**
+
+```bash
+vrg-git add scripts/bin/validate-custom
+vrg-commit --type build --scope validate \
+  --message "wire hook test suites into vrg-validate via validate-custom" \
+  --body "Adds the repo-local custom validator that vrg-validate discovers at scripts/bin/validate-custom; it runs every hooks/tests/*.test.sh, bringing the matcher and audit-guard suites into the validation pipeline. Spec section 6.5. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 12: Document quote-stripped matching
+
+**Files:**
+- Modify: `docs/site/docs/hooks/index.md`
+
+- [ ] **Step 1: Add the section**
+
+In `docs/site/docs/hooks/index.md`, insert the following new section
+immediately after the `## Managed-repo gating` section (i.e., before
+`## PreToolUse Hooks — Bash`):
+
+```markdown
+## Command matching: quote-stripping
+
+Every Bash-command matcher below (except `block-heredoc`) tests
+tool names against a **quote-stripped** copy of the command string:
+single- and double-quoted spans are replaced with `""` first, then
+the tool name must appear in command position
+(`(^|[;&|({]\s*)<tool>(\s|$)`, applied per line).
+
+This is why a commit body or issue body that *mentions* a blocked
+command — even at the start of a line inside a multi-line `--body`
+argument — does not trigger a false deny, while the same text in
+command position still does.
+
+`block-heredoc` matches raw text: its regex must see the quoted
+delimiter in `<<'EOF'`, which stripping would remove.
+
+Canonical rule, accepted gaps, and the shared test vectors:
+[`docs/specs/2026-06-05-450-command-matcher-quoting-design.md`](https://github.com/vergil-project/vergil-claude-plugin/blob/develop/docs/specs/2026-06-05-450-command-matcher-quoting-design.md).
+See [issue #450](https://github.com/vergil-project/vergil-claude-plugin/issues/450).
+```
+
+- [ ] **Step 2: Verify docs build and validation**
+
+```bash
+vrg-container-run -- vrg-validate
+```
+
+Expected: exit 0 (markdownlint passes on the new section).
+
+- [ ] **Step 3: Commit**
+
+```bash
+vrg-git add docs/site/docs/hooks/index.md
+vrg-commit --type docs --scope hooks \
+  --message "document quote-stripped command matching" \
+  --body "Adds a hooks-page section explaining that matchers test quote-stripped text at command position, why prose mentions of blocked commands no longer false-deny, and why block-heredoc is exempt. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+---
+
+### Task 13: File the vergil-tooling sub-issue and link it in the spec
+
+**Files:**
+- Create: `/tmp/vt-450-subissue-body.md` (scratch, not committed)
+- Modify: `docs/specs/2026-06-05-450-command-matcher-quoting-design.md`
+
+- [ ] **Step 1: Write the issue body**
+
+Write `/tmp/vt-450-subissue-body.md` with exactly this content:
+
+```markdown
+Sub-issue of vergil-project/vergil-claude-plugin#450 — the
+`vrg-hook-guard` half.
+
+The guard's `_RAW_GIT_RE` / `_RAW_GH_RE` use the lookbehind
+`(?<![a-zA-Z0-9_-])`, which matches tool names preceded by `.` or
+`/`, producing false denies on commands like
+`find . -path ./.git -prune` (observed live 2026-06-05).
+
+The canonical rule (quote-strip, then anchor at command position)
+and the shared test vectors are defined in the plugin spec:
+`docs/specs/2026-06-05-450-command-matcher-quoting-design.md`
+(sections 2, 4, and 6.1).
+
+Changes for this repo (spec section 4):
+
+1. `_QUOTED_STR_RE` becomes the single alternation
+   `"(\\.|[^"\\])*"|'[^']*'` (escape-aware for double quotes).
+2. The lookbehind becomes the canonical anchor
+   `(^|[;&|({]\s*)git(\s|$)` (resp. `gh`) with `re.MULTILINE`.
+3. The `bash -c` recheck is confined to the extracted quoted
+   argument instead of the whole raw command (spec section 4.3).
+4. `tests/vergil_tooling/test_vrg_hook_guard.py` encodes the spec
+   section 6.1 table verbatim, including rows 11-12.
+```
+
+- [ ] **Step 2: Create the issue**
+
+```bash
+vrg-gh issue create \
+  --repo vergil-project/vergil-tooling \
+  --title "vrg-hook-guard: adopt canonical quote-strip + command-position matcher (vergil-claude-plugin#450)" \
+  --body-file /tmp/vt-450-subissue-body.md
+```
+
+Record the issue number `<N>` printed in the output URL.
+
+- [ ] **Step 3: Link it in the spec header**
+
+In `docs/specs/2026-06-05-450-command-matcher-quoting-design.md`,
+replace the header clause:
+
+```markdown
+(this repo) · vergil-tooling sub-issue to be filed for the
+`vrg-hook-guard` half (linked here once created)
+```
+
+with (substituting the real `<N>`):
+
+```markdown
+(this repo) ·
+[vergil-tooling#<N>](https://github.com/vergil-project/vergil-tooling/issues/<N>)
+(the `vrg-hook-guard` half)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+vrg-git add docs/specs/2026-06-05-450-command-matcher-quoting-design.md
+vrg-commit --type docs --scope specs \
+  --message "link the filed vergil-tooling sub-issue in the matcher spec" \
+  --body "Records the vrg-hook-guard companion issue number in the spec header now that it exists. Ref vergil-project/vergil-claude-plugin#450."
+```
+
+Note: formal GitHub sub-issue linkage uses `gh api`, which `vrg-gh`
+denies; if the human wants the parent/child relation recorded in
+GitHub's sub-issue graph, surface that as a one-line ask at handoff.
+
+---
+
+### Task 14: Final validation and handoff
+
+**Files:**
+- Create: `.vergil/pr-template.yml` (via `.tmp` + `mv`, not committed)
+
+- [ ] **Step 1: Run the full suite one last time**
+
+```bash
+bash scripts/bin/validate-custom
+vrg-container-run -- vrg-validate
+```
+
+Expected: both exit 0. If anything fails, fix it before proceeding —
+never hand off red.
+
+- [ ] **Step 2: Verify the worktree is clean and pushed state is known**
+
+```bash
+vrg-git status
+vrg-git log --oneline origin/develop..HEAD
+```
+
+Expected: clean tree; the log lists every commit from Tasks 1–13
+plus the two spec commits and the plan commit made during design.
+
+- [ ] **Step 3: Write the PR handoff template**
+
+Write `.vergil/pr-template.yml.tmp` with this content, then
+`mv .vergil/pr-template.yml.tmp .vergil/pr-template.yml` (atomic,
+per the implement-skill contract):
+
+```yaml
+issue: 450
+title: "fix(hooks): stop command matchers false-matching quoted multi-line arguments"
+summary: "Quote-strip command text before tool-name matching across nine hook scripts; shared lib + canonical test vectors; vrg-hook-guard companion issue filed in vergil-tooling"
+notes: "Spec: docs/specs/2026-06-05-450-command-matcher-quoting-design.md. Consumers need a plugin refresh after merge."
+```
+
+- [ ] **Step 4: Hand off**
+
+Tell the human:
+
+- the branch (`bugfix/450-matcher-quoted-args`) is validated green
+  and ready for `vrg-submit-pr` (use `--linkage Ref` — auto-close
+  keywords are blocked);
+- the vergil-tooling sub-issue number from Task 13, and that the
+  parent/child sub-issue linkage (if wanted) needs a human `gh api`
+  call;
+- after merge to develop, consumers refresh with
+  `/plugin marketplace update vergil-marketplace` then
+  `/reload-plugins`.

--- a/docs/site/docs/hooks/index.md
+++ b/docs/site/docs/hooks/index.md
@@ -36,6 +36,26 @@ you're in, so the rule is universal.
 See [issue #87](https://github.com/vergil-project/vergil-claude-plugin/issues/87)
 for the rationale.
 
+## Command matching: quote-stripping
+
+Every Bash-command matcher below (except `block-heredoc`) tests
+tool names against a **quote-stripped** copy of the command string:
+single- and double-quoted spans are replaced with `""` first, then
+the tool name must appear in command position
+(`(^|[;&|({]\s*)<tool>(\s|$)`, applied per line).
+
+This is why a commit body or issue body that *mentions* a blocked
+command — even at the start of a line inside a multi-line `--body`
+argument — does not trigger a false deny, while the same text in
+command position still does.
+
+`block-heredoc` matches raw text: its regex must see the quoted
+delimiter in `<<'EOF'`, which stripping would remove.
+
+Canonical rule, accepted gaps, and the shared test vectors:
+[`docs/specs/2026-06-05-450-command-matcher-quoting-design.md`](https://github.com/vergil-project/vergil-claude-plugin/blob/develop/docs/specs/2026-06-05-450-command-matcher-quoting-design.md).
+See [issue #450](https://github.com/vergil-project/vergil-claude-plugin/issues/450).
+
 ## PreToolUse Hooks — Bash
 
 ### block-raw-git-commit

--- a/docs/specs/2026-06-05-450-command-matcher-quoting-design.md
+++ b/docs/specs/2026-06-05-450-command-matcher-quoting-design.md
@@ -4,8 +4,9 @@
 pushback-reviewed 2026-06-05, resolutions folded in) ·
 **Date:** 2026-06-05 ·
 **Issues:** [#450](https://github.com/vergil-project/vergil-claude-plugin/issues/450)
-(this repo) · vergil-tooling sub-issue to be filed for the
-`vrg-hook-guard` half (linked here once created)
+(this repo) ·
+[vergil-tooling#1443](https://github.com/vergil-project/vergil-tooling/issues/1443)
+(the `vrg-hook-guard` half)
 
 PreToolUse hook matchers scan the raw Bash command text for tool
 names. Two implementations exist — bash regexes in this repo's

--- a/docs/specs/2026-06-05-450-command-matcher-quoting-design.md
+++ b/docs/specs/2026-06-05-450-command-matcher-quoting-design.md
@@ -114,6 +114,10 @@ Documented so nobody re-litigates them later:
   keyword, not a separator — a false-negative shape, not covered.
   Extending the anchor to a keyword alternation works against the
   one-rule-two-engines goal (§6.1).
+- Trailing-punctuation adjacency: the `(\s|$)` tail means a matched
+  phrase whose final word abuts `)` or `;` with no space — e.g.
+  `$(git commit)` with no arguments — is missed. False-negative
+  shape, pre-existing, kept (real invocations carry arguments).
 - The rare combination where a *real* commit command also contains
   quoted prose matching `git -C <dir> commit`: the raw-text
   directory extraction in `block-protected-branch-work.sh` (§2.3)
@@ -238,17 +242,18 @@ literal newline inside a quoted argument.
 | --- | --- | --- | --- |
 | 1 | `git commit -m x` | match | plain invocation |
 | 2 | `cd foo && git commit` | match | separator |
-| 3 | `$(git commit)` | match | `(` separator |
-| 4 | `{ git commit; }` | match | `{` separator |
+| 3 | `x=$(git commit -m x)` | match | `(` separator |
+| 4 | `{ git commit -m x; }` | match | `{` separator |
 | 5 | `vrg-commit --body "line one⏎git commit prose"` | no match | #450 repro |
 | 6 | `find . -path ./.git -prune` | no match | position anchor |
 | 7 | `echo "git commit"` | no match | quoted span stripped |
 | 8 | `echo 'say "git commit"'` | no match | nesting |
 | 9 | `echo "he said \"git commit\""` | no match | escape handling |
-| 10 | `echo "git commit` | match | unbalanced quote — accepted FP direction (§2.1) |
+| 10 | `echo "; git commit` | match | unbalanced quote with a separator inside the span — accepted FP direction (§2.1) |
 | 11 | `bash -c "git commit"` | match | recheck path — **vrg-hook-guard only** |
 | 12 | `bash -c 'true' && vrg-commit --body "git commit prose"` | no match | recheck confinement (§4.3) — **vrg-hook-guard only** |
 | 13 | `if git commit; then :; fi` | no match | keyword position — accepted gap (§2.4) |
+| 14 | `echo "git commit` | no match | unbalanced quote; the unstripped `"` is not a separator |
 
 Rows 11–12 apply only to `vrg-hook-guard`; the plugin scripts have
 no `bash -c` recheck (§2.4).
@@ -258,7 +263,7 @@ no `bash -c` recheck (§2.4).
 Table-driven (bash-3.2 parallel arrays, per the
 `guard-audit-writes.test.sh` convention), exercising
 `strip_quoted_segments` directly: the stripping-relevant §6.1
-vectors (5, 7–10) plus the empty command.
+vectors (5, 7–10, 14) plus the empty command.
 
 ### 6.3 Plugin — `hooks/tests/command-matchers.test.sh`
 

--- a/docs/specs/2026-06-05-450-command-matcher-quoting-design.md
+++ b/docs/specs/2026-06-05-450-command-matcher-quoting-design.md
@@ -1,0 +1,246 @@
+# Command-Matcher Quoting — Design
+
+**Status:** Design (approved in brainstorm 2026-06-05) ·
+**Date:** 2026-06-05 ·
+**Issues:** [#450](https://github.com/vergil-project/vergil-claude-plugin/issues/450)
+(this repo) · vergil-tooling sub-issue to be filed for the
+`vrg-hook-guard` half (linked here once created)
+
+PreToolUse hook matchers scan the raw Bash command text for tool
+names. Two implementations exist — bash regexes in this repo's
+`hooks/scripts/` and Python in vergil-tooling's `vrg-hook-guard` —
+and each has the half of the correct matcher the other is missing:
+
+| Implementation | Quote-aware? | Command-position anchored? | Resulting false positive |
+| --- | --- | --- | --- |
+| Plugin scripts | no | yes — `(^\|[;&\|]\s*)` | tool name at line start inside a quoted multi-line `--body`/`--message` argument (#450) |
+| `vrg-hook-guard` | yes (naive) | no — lookbehind `(?<![a-zA-Z0-9_-])` | `./.git`, `/usr/lib/git`, any `.`/`/`-prefixed hit (observed live: `find … -path ./.git` denied) |
+
+Both defects are the same class: the matcher cannot tell command
+position from argument content. This spec defines one canonical
+matcher rule and applies it to both implementations.
+
+## 1. Decisions confirmed in brainstorm (2026-06-05)
+
+1. **Scope: both repos, one design.** The shared matcher strategy is
+   specified once here; implementation lands as two PRs (one per
+   repo).
+2. **Crude quote-stripping is the end state.** These hooks guard
+   against agent slip-ups, not adversarial evasion. The
+   `vrg-git`/`vrg-gh` wrappers (subcommand allowlists, credential
+   selection) remain the real enforcement layer. No follow-up path to
+   shell tokenization.
+3. **Spec lives in this repo; vergil-tooling gets a sub-issue.**
+   Issue #450 is filed here and 9 of the 10 affected matchers are
+   here. The sub-issue links back to #450 and this spec.
+
+## 2. The canonical matcher rule
+
+> A tool-name predicate matches only when the tool name appears in
+> command position in the quote-stripped command text.
+
+### 2.1 Quote stripping
+
+A single left-to-right pass replaces quoted spans with the
+placeholder `""`:
+
+```text
+"(\\.|[^"\\])*"   double-quoted span, honoring backslash escapes
+'[^']*'           single-quoted span, no escapes (shell semantics)
+```
+
+Combined as **one alternation** so leftmost-match-wins mirrors how
+the shell itself scans the command. This handles nesting
+(`"don't"`, `'say "hi"'`) without special cases.
+
+- The placeholder `""` (rather than deletion) preserves token
+  boundaries.
+- Unbalanced quotes leave the remainder unstripped. That input is a
+  shell syntax error anyway, and the failure direction is a false
+  positive (over-blocking) — never a weakened guard. Accepted.
+
+### 2.2 Command-position anchoring
+
+```text
+(^|[;&|(]\s*)<tool>(\s|$)
+```
+
+Applied per line (grep's natural behavior in bash; `re.MULTILINE`
+in Python). Line starts are real command positions *after*
+stripping, because multi-line quoted arguments are gone.
+
+One deliberate hardening over the current plugin anchor: `(` joins
+the separator class so subshells — `(git …)` and `$(git …)` — are
+caught.
+
+### 2.3 Predicate classification
+
+Not every predicate moves to stripped text:
+
+- **Tool-name predicates** (is `git commit` / `gh pr create` /
+  `vrg-submit-pr` being *invoked*?) → match against **stripped**
+  text with the canonical anchor.
+- **Argument-content predicates** (contents-API URLs, HTTP-method
+  flags, `--linkage` values) → keep matching **raw** text. Their
+  targets legitimately live inside quotes; stripping would create
+  false negatives.
+
+### 2.4 Accepted gaps (out of scope)
+
+Documented so nobody re-litigates them later:
+
+- Escaped quotes outside any quote context (`\"git commit\"` at top
+  level).
+- `eval` indirection.
+- Command substitution nested inside double quotes.
+- The plugin scripts have no `bash -c` recheck (and never did);
+  only `vrg-hook-guard` carries one (§4.3).
+
+All are agent-evasion shapes, not slip-up shapes (decision 2).
+
+## 3. Plugin-repo changes
+
+### 3.1 New shared helper
+
+`hooks/scripts/lib/command-match.sh` — sourceable, following the
+`managed-repo-check.sh` convention. Provides:
+
+```bash
+strip_quoted_segments <command-text>   # → stripped text on stdout
+```
+
+Implementation note: `sed`/`grep` are line-oriented and cannot span
+the multi-line quoted strings that cause #450. The stripper is
+jq-based — jq is already a hard dependency of every hook script,
+and its `gsub` (Oniguruma) operates on the whole string:
+
+```bash
+jq -Rsr 'gsub("\"(\\\\.|[^\"\\\\])*\"|'\''[^'\'']*'\''"; "\"\"")'
+```
+
+(Exact escaping to be settled in implementation; the regex is the
+§2.1 alternation.)
+
+### 3.2 Per-script changes
+
+Pattern everywhere: compute `stripped=$(strip_quoted_segments
+"$command")` once; point tool-name predicates at `$stripped`; leave
+argument-content predicates on `$command`.
+
+| Script | Change |
+| --- | --- |
+| `block-raw-git-commit.sh` | fallback `git commit` regex → stripped |
+| `block-raw-gh-pr-create.sh` | both predicates → stripped |
+| `block-agent-merge.sh` | all three predicates → stripped |
+| `enforce-host-container-split.sh` | both loop matchers → stripped |
+| `detect-deprecation-warnings.sh` | command matcher → stripped (the *output* scan for deprecation warnings is untouched) |
+| `block-protected-branch-work.sh` | inverted matcher → stripped — fixes the guard-*weakening* direction noted in #450 |
+| `block-autoclose-linkage.sh` | loose `vrg-submit-pr\b` → canonical anchor on stripped; `--linkage (Fixes\|Closes\|Resolves)` value check stays raw |
+| `block-github-contents-api.sh` | `gh api` tool-name check → stripped; contents-URL and HTTP-method checks stay raw |
+| `block-associative-arrays.sh` | `declare -A` matcher → stripped |
+| `block-heredoc.sh` | **unchanged** — its regex must see the quoted delimiter in `<<'EOF'`; stripping would break real heredoc detection. FP on prose mentioning heredocs remains, accepted |
+
+The last two table rows (`block-github-contents-api.sh`,
+`block-associative-arrays.sh`) go beyond #450's listed scripts;
+they are the identical one-line fix and were approved in brainstorm
+to avoid leaving known instances of the defect class behind.
+
+All anchored regexes also pick up the `(` separator from §2.2.
+
+## 4. vergil-tooling changes (`vrg_hook_guard.py`)
+
+### 4.1 Stripper upgrade
+
+`_QUOTED_STR_RE` becomes the §2.1 alternation (adds `\"` escape
+handling inside double quotes).
+
+### 4.2 Anchor replacement
+
+`_RAW_GIT_RE` / `_RAW_GH_RE` lookbehind `(?<![a-zA-Z0-9_-])` is
+replaced with the canonical anchor `(^|[;&|(]\s*)git(\s|$)` (resp.
+`gh`) compiled with `re.MULTILINE`. This fixes the `./.git` and
+path-prefix false positives.
+
+### 4.3 `bash -c` recheck preserved — with an extended anchor
+
+Today, when the stripped text contains `bash -c`, the guard
+rechecks the *raw* text because the quoted argument of `bash -c`
+*is* command text. The canonical anchor would break that recheck
+(in `bash -c "git commit"`, `git` is preceded by `"`). The recheck
+path therefore uses an extended separator class that includes quote
+characters:
+
+```text
+(^|[;&|("']\s*)<tool>(\s|$)
+```
+
+Slightly looser, but applied only to commands containing
+`bash -c`; the over-blocking surface is tiny and the alternative is
+an evasion regression.
+
+## 5. Error handling
+
+The stripper has no silent-failure path. If jq unexpectedly errors,
+`set -euo pipefail` aborts the hook script non-zero and Claude Code
+surfaces a visible non-blocking error — the same behavior as
+today's jq input parsing. No fallback-to-raw-text, no swallowed
+errors: a broken stripper fails loudly rather than quietly
+reverting to the buggy matching.
+
+## 6. Testing
+
+### 6.1 Plugin — `hooks/tests/command-match.test.sh`
+
+Table-driven (bash-3.2 parallel arrays, per the
+`guard-audit-writes.test.sh` convention), exercising
+`strip_quoted_segments` directly:
+
+- the #450 repro — multi-line `--body` with `git commit` at line
+  start → stripped text contains no `git commit`
+- escaped quotes inside double-quoted spans
+- nesting: `"don't"`, `'say "hi"'`
+- unbalanced quote → remainder unstripped (documented FP direction)
+- empty command
+
+### 6.2 Plugin — `hooks/tests/command-matchers.test.sh`
+
+Per-script allow/deny table feeding hook JSON to each of the nine
+changed scripts. Representative cases:
+
+- #450 repro payload → allow
+- plain `git commit -m x` → deny
+- `cd foo && git commit` → deny
+- `$(git commit)` → deny (new `(` separator)
+- inverted-guard case for `block-protected-branch-work.sh`: a
+  quoted-body `git commit` mention on a protected branch no longer
+  *skips* the guard
+
+`block-raw-git-commit.sh` is tested with `vrg-hook-guard` masked
+from `PATH` so the fallback regex path is what runs.
+
+### 6.3 vergil-tooling — `tests/vergil_tooling/test_vrg_hook_guard.py`
+
+Extend the existing pytest module:
+
+- `find … -path ./.git` → allow (the live regression)
+- multi-line quoted body with `git commit` at line start → allow
+- `bash -c "git commit"` → still deny (recheck path)
+- plain `git commit` / `gh pr create` → still deny
+
+### 6.4 Validation
+
+`vrg-container-run -- vrg-validate` in each repo. If the hook test
+scripts are not yet wired into `vrg-validate`, wiring them in is
+part of the implementation plan, not this spec.
+
+## 7. Rollout
+
+1. **This repo:** PR from `bugfix/450-matcher-quoted-args` →
+   `develop`, resolving #450. Ref-only linkage per policy — the
+   issue is closed manually by the human after finalization, never
+   by auto-close keywords.
+2. **vergil-tooling:** sub-issue filed (links #450 + this spec),
+   own branch/PR cycle.
+3. After the plugin PR merges to `develop`, consumers refresh:
+   `/plugin marketplace update vergil-marketplace` →
+   `/reload-plugins`.

--- a/docs/specs/2026-06-05-450-command-matcher-quoting-design.md
+++ b/docs/specs/2026-06-05-450-command-matcher-quoting-design.md
@@ -1,6 +1,7 @@
 # Command-Matcher Quoting — Design
 
-**Status:** Design (approved in brainstorm 2026-06-05) ·
+**Status:** Design (approved in brainstorm 2026-06-05;
+pushback-reviewed 2026-06-05, resolutions folded in) ·
 **Date:** 2026-06-05 ·
 **Issues:** [#450](https://github.com/vergil-project/vergil-claude-plugin/issues/450)
 (this repo) · vergil-tooling sub-issue to be filed for the
@@ -62,16 +63,20 @@ the shell itself scans the command. This handles nesting
 ### 2.2 Command-position anchoring
 
 ```text
-(^|[;&|(]\s*)<tool>(\s|$)
+(^|[;&|({]\s*)<tool>(\s|$)
 ```
 
 Applied per line (grep's natural behavior in bash; `re.MULTILINE`
 in Python). Line starts are real command positions *after*
 stripping, because multi-line quoted arguments are gone.
 
-One deliberate hardening over the current plugin anchor: `(` joins
-the separator class so subshells — `(git …)` and `$(git …)` — are
-caught.
+Two deliberate hardenings over the current plugin anchor:
+
+- `(` joins the separator class so subshells — `(git …)` and
+  `$(git …)` — are caught.
+- `{` joins it so brace groups — `{ git commit; }` — are caught.
+  Brace expansion (`{git,x}`) cannot false-positive: no whitespace
+  follows the brace there, so `(\s|$)` does not fire.
 
 ### 2.3 Predicate classification
 
@@ -84,6 +89,12 @@ Not every predicate moves to stripped text:
   flags, `--linkage` values) → keep matching **raw** text. Their
   targets legitimately live inside quotes; stripping would create
   false negatives.
+- **Directory-extraction predicates** (the `cd <dir>` /
+  `git -C <dir>` prefix extraction in
+  `block-protected-branch-work.sh` that resolves where a commit
+  will actually run) → keep matching **raw** text. Their targets
+  are paths, which are legitimately quoted (`cd "/path with
+  space"`).
 
 ### 2.4 Accepted gaps (out of scope)
 
@@ -93,6 +104,22 @@ Documented so nobody re-litigates them later:
   level).
 - `eval` indirection.
 - Command substitution nested inside double quotes.
+- ANSI-C quoting (`$'…'`): bash allows `\'` escapes inside it, the
+  one place single-quoting permits them. The stripper ends the span
+  at the `\'`, leaving the remainder unstripped — a false-positive
+  direction only, consistent with the unbalanced-quote stance
+  (§2.1).
+- Shell keywords as command position (`if git commit; then`,
+  `do git commit`, `else git commit`): the tool name follows a
+  keyword, not a separator — a false-negative shape, not covered.
+  Extending the anchor to a keyword alternation works against the
+  one-rule-two-engines goal (§6.1).
+- The rare combination where a *real* commit command also contains
+  quoted prose matching `git -C <dir> commit`: the raw-text
+  directory extraction in `block-protected-branch-work.sh` (§2.3)
+  can mis-resolve the effective directory. The gating matcher on
+  stripped text confines this to commands that genuinely commit,
+  which makes the combination vanishingly rare.
 - The plugin scripts have no `bash -c` recheck (and never did);
   only `vrg-hook-guard` carries one (§4.3).
 
@@ -134,7 +161,7 @@ argument-content predicates on `$command`.
 | `block-agent-merge.sh` | all three predicates → stripped |
 | `enforce-host-container-split.sh` | both loop matchers → stripped |
 | `detect-deprecation-warnings.sh` | command matcher → stripped (the *output* scan for deprecation warnings is untouched) |
-| `block-protected-branch-work.sh` | inverted matcher → stripped — fixes the guard-*weakening* direction noted in #450 |
+| `block-protected-branch-work.sh` | gating matcher → stripped. Note: #450 records this as guard-*weakening*; reading the script shows the opposite — the matcher gates whether the guard applies, so a quoted-prose hit subjects *non-commit* commands to the worktree/branch check (over-blocking). The `cd`/`git -C` directory-extraction greps stay on raw text per §2.3 |
 | `block-autoclose-linkage.sh` | loose `vrg-submit-pr\b` → canonical anchor on stripped; `--linkage (Fixes\|Closes\|Resolves)` value check stays raw |
 | `block-github-contents-api.sh` | `gh api` tool-name check → stripped; contents-URL and HTTP-method checks stay raw |
 | `block-associative-arrays.sh` | `declare -A` matcher → stripped |
@@ -145,7 +172,8 @@ The last two table rows (`block-github-contents-api.sh`,
 they are the identical one-line fix and were approved in brainstorm
 to avoid leaving known instances of the defect class behind.
 
-All anchored regexes also pick up the `(` separator from §2.2.
+All anchored regexes also pick up the `(` and `{` separators from
+§2.2.
 
 ## 4. vergil-tooling changes (`vrg_hook_guard.py`)
 
@@ -157,26 +185,31 @@ handling inside double quotes).
 ### 4.2 Anchor replacement
 
 `_RAW_GIT_RE` / `_RAW_GH_RE` lookbehind `(?<![a-zA-Z0-9_-])` is
-replaced with the canonical anchor `(^|[;&|(]\s*)git(\s|$)` (resp.
+replaced with the canonical anchor `(^|[;&|({]\s*)git(\s|$)` (resp.
 `gh`) compiled with `re.MULTILINE`. This fixes the `./.git` and
 path-prefix false positives.
 
-### 4.3 `bash -c` recheck preserved — with an extended anchor
+### 4.3 `bash -c` recheck — confined to the extracted argument
 
 Today, when the stripped text contains `bash -c`, the guard
 rechecks the *raw* text because the quoted argument of `bash -c`
-*is* command text. The canonical anchor would break that recheck
-(in `bash -c "git commit"`, `git` is preceded by `"`). The recheck
-path therefore uses an extended separator class that includes quote
-characters:
+*is* command text. Rechecking the **whole** raw text, however,
+would resurrect the #450 false-positive shape for any command that
+happens to contain `bash -c` anywhere: one unrelated `bash -c`
+flips the entire command — including long quoted `--body` prose —
+back to raw matching.
 
-```text
-(^|[;&|("']\s*)<tool>(\s|$)
-```
+Instead, the recheck is confined to the text that actually is
+command text: when the stripped text matches `bash -c`, extract
+the quoted span(s) immediately following `bash -c` from the raw
+text and run the canonical §2.2 matcher against that extracted
+content only. Still crude — "the quoted string after `bash -c`",
+no parsing — consistent with decision 2.
 
-Slightly looser, but applied only to commands containing
-`bash -c`; the over-blocking surface is tiny and the alternative is
-an evasion regression.
+- `bash -c "git commit"` → extracted `git commit` → matches at
+  `^` → deny.
+- `bash -c 'true' && vrg-commit --body "…git commit prose…"` →
+  recheck sees only `true`; the body stays stripped → allow.
 
 ## 5. Error handling
 
@@ -189,45 +222,65 @@ reverting to the buggy matching.
 
 ## 6. Testing
 
-### 6.1 Plugin — `hooks/tests/command-match.test.sh`
+### 6.1 Canonical case table (shared vectors)
+
+The rule is implemented twice (jq/Oniguruma, Python `re`) — the
+exact condition under which near-identical regexes drift silently.
+Both test suites (§6.3 plugin, §6.4 tooling) **must encode this
+table verbatim**, each in its own harness, with a comment pointing
+at this section. Drift between the implementations then requires
+editing this table — a visible act.
+
+Verdicts are for the raw-`git`-invocation predicate; `⏎` marks a
+literal newline inside a quoted argument.
+
+| # | Command | Verdict | Exercises |
+| --- | --- | --- | --- |
+| 1 | `git commit -m x` | match | plain invocation |
+| 2 | `cd foo && git commit` | match | separator |
+| 3 | `$(git commit)` | match | `(` separator |
+| 4 | `{ git commit; }` | match | `{` separator |
+| 5 | `vrg-commit --body "line one⏎git commit prose"` | no match | #450 repro |
+| 6 | `find . -path ./.git -prune` | no match | position anchor |
+| 7 | `echo "git commit"` | no match | quoted span stripped |
+| 8 | `echo 'say "git commit"'` | no match | nesting |
+| 9 | `echo "he said \"git commit\""` | no match | escape handling |
+| 10 | `echo "git commit` | match | unbalanced quote — accepted FP direction (§2.1) |
+| 11 | `bash -c "git commit"` | match | recheck path — **vrg-hook-guard only** |
+| 12 | `bash -c 'true' && vrg-commit --body "git commit prose"` | no match | recheck confinement (§4.3) — **vrg-hook-guard only** |
+| 13 | `if git commit; then :; fi` | no match | keyword position — accepted gap (§2.4) |
+
+Rows 11–12 apply only to `vrg-hook-guard`; the plugin scripts have
+no `bash -c` recheck (§2.4).
+
+### 6.2 Plugin — `hooks/tests/command-match.test.sh`
 
 Table-driven (bash-3.2 parallel arrays, per the
 `guard-audit-writes.test.sh` convention), exercising
-`strip_quoted_segments` directly:
+`strip_quoted_segments` directly: the stripping-relevant §6.1
+vectors (5, 7–10) plus the empty command.
 
-- the #450 repro — multi-line `--body` with `git commit` at line
-  start → stripped text contains no `git commit`
-- escaped quotes inside double-quoted spans
-- nesting: `"don't"`, `'say "hi"'`
-- unbalanced quote → remainder unstripped (documented FP direction)
-- empty command
-
-### 6.2 Plugin — `hooks/tests/command-matchers.test.sh`
+### 6.3 Plugin — `hooks/tests/command-matchers.test.sh`
 
 Per-script allow/deny table feeding hook JSON to each of the nine
-changed scripts. Representative cases:
-
-- #450 repro payload → allow
-- plain `git commit -m x` → deny
-- `cd foo && git commit` → deny
-- `$(git commit)` → deny (new `(` separator)
-- inverted-guard case for `block-protected-branch-work.sh`: a
-  quoted-body `git commit` mention on a protected branch no longer
-  *skips* the guard
+changed scripts: the §6.1 vectors (minus 11–12) plus per-script
+cases, notably for `block-protected-branch-work.sh`: a non-commit
+command whose quoted body mentions `git commit`, run at the
+project root, is no longer denied (the over-blocking direction,
+§3.2).
 
 `block-raw-git-commit.sh` is tested with `vrg-hook-guard` masked
 from `PATH` so the fallback regex path is what runs.
 
-### 6.3 vergil-tooling — `tests/vergil_tooling/test_vrg_hook_guard.py`
+### 6.4 vergil-tooling — `tests/vergil_tooling/test_vrg_hook_guard.py`
 
-Extend the existing pytest module:
+Extend the existing pytest module: the full §6.1 table (including
+rows 11–12), plus:
 
 - `find … -path ./.git` → allow (the live regression)
-- multi-line quoted body with `git commit` at line start → allow
-- `bash -c "git commit"` → still deny (recheck path)
-- plain `git commit` / `gh pr create` → still deny
+- plain `gh pr create` → still deny
 
-### 6.4 Validation
+### 6.5 Validation
 
 `vrg-container-run -- vrg-validate` in each repo. If the hook test
 scripts are not yet wired into `vrg-validate`, wiring them in is

--- a/hooks/scripts/block-agent-merge.sh
+++ b/hooks/scripts/block-agent-merge.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
 
 input=$(cat)
 cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
@@ -23,20 +25,21 @@ if ! is_managed_repo "$cwd"; then
 fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
 
 is_merge_command=false
 
-if echo "$command" \
-     | grep -qE '(^|[;&|]\s*)gh\s+pr\s+(merge(\s|$)|review\s+.*--approve)'; then
+if echo "$stripped" \
+     | grep -qE '(^|[;&|({]\s*)gh\s+pr\s+(merge(\s|$)|review\s+.*--approve)'; then
   is_merge_command=true
 fi
 
-if echo "$command" | grep -qE 'gh\s+api\s+.*/pulls/[0-9]+/merge(\s|$)' \
+if echo "$stripped" | grep -qE 'gh\s+api\s+.*/pulls/[0-9]+/merge(\s|$)' \
   && echo "$command" | grep -qiE '(-X\s+PUT|--method\s+PUT|-XPUT)'; then
   is_merge_command=true
 fi
 
-if echo "$command" | grep -qE 'gh\s+api\s+.*/pulls/[0-9]+/reviews(\s|$)' \
+if echo "$stripped" | grep -qE 'gh\s+api\s+.*/pulls/[0-9]+/reviews(\s|$)' \
   && echo "$command" | grep -qiE '(-X\s+POST|--method\s+POST|-XPOST)'; then
   is_merge_command=true
 fi

--- a/hooks/scripts/block-associative-arrays.sh
+++ b/hooks/scripts/block-associative-arrays.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
 
 input=$(cat)
 cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
@@ -19,9 +21,10 @@ if ! is_managed_repo "$cwd"; then
 fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
 
 # Match declare with -A flag in any position (e.g., -A, -Ag, -rA, -gA).
-if echo "$command" | grep -qE 'declare\s+-[a-zA-Z]*A'; then
+if echo "$stripped" | grep -qE 'declare\s+-[a-zA-Z]*A'; then
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/hooks/scripts/block-autoclose-linkage.sh
+++ b/hooks/scripts/block-autoclose-linkage.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
 
 input=$(cat)
 cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
@@ -19,8 +21,9 @@ if ! is_managed_repo "$cwd"; then
 fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
 
-if echo "$command" | grep -qE 'vrg-submit-pr\b'; then
+if echo "$stripped" | grep -qE '(^|[;&|({]\s*)vrg-submit-pr(\s|$)'; then
   if echo "$command" | grep -qiE -- '--linkage\s+(Fixes|Closes|Resolves)\b'; then
     jq -n '{
       hookSpecificOutput: {

--- a/hooks/scripts/block-github-contents-api.sh
+++ b/hooks/scripts/block-github-contents-api.sh
@@ -19,11 +19,14 @@ cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
 if ! is_managed_repo "$cwd"; then
   exit 0
 fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
 
 # Check if the command uses gh api targeting the Contents API with a write method.
 #
@@ -43,7 +46,7 @@ has_contents_url=false
 has_write_method=false
 
 # Check for Contents API URL (short or full form).
-if echo "$command" | grep -qE 'gh\s+api\s' && echo "$command" | grep -qE '(repos/[^[:space:]]*/contents/|https://api\.github\.com/repos/[^[:space:]]*/contents/)'; then
+if echo "$stripped" | grep -qE 'gh\s+api\s' && echo "$command" | grep -qE '(repos/[^[:space:]]*/contents/|https://api\.github\.com/repos/[^[:space:]]*/contents/)'; then
   has_contents_url=true
 fi
 

--- a/hooks/scripts/block-protected-branch-work.sh
+++ b/hooks/scripts/block-protected-branch-work.sh
@@ -26,15 +26,18 @@ cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
 if ! is_managed_repo "$cwd"; then
   exit 0
 fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
 
 # Only check commands that could create commits on the current branch.
 # Allow git operations that don't create commits (checkout, push, pull, etc.).
-if ! echo "$command" | grep -qE '(^|[;&|]\s*)(git\s+commit|vrg-commit)(\s|$)'; then
+if ! echo "$stripped" | grep -qE '(^|[;&|({]\s*)(git\s+commit|vrg-commit)(\s|$)'; then
   exit 0
 fi
 

--- a/hooks/scripts/block-raw-gh-pr-create.sh
+++ b/hooks/scripts/block-raw-gh-pr-create.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
 
 input=$(cat)
 cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
@@ -18,6 +20,7 @@ if ! is_managed_repo "$cwd"; then
 fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
 
 deny() {
   jq -n --arg reason "$1" '{
@@ -29,9 +32,9 @@ deny() {
   }'
 }
 
-if echo "$command" | grep -qE '(^|[;&|]\s*)gh\s+pr\s+create(\s|$)'; then
+if echo "$stripped" | grep -qE '(^|[;&|({]\s*)gh\s+pr\s+create(\s|$)'; then
   deny "Raw gh pr create is blocked. Use vrg-submit-pr instead. All gh operations should use vrg-gh, which enforces subcommand allowlists, credential selection, and audit logging."
-elif echo "$command" | grep -qE 'gh\s+api\s+.*(/pulls)(\s|$)' \
+elif echo "$stripped" | grep -qE 'gh\s+api\s+.*(/pulls)(\s|$)' \
   && echo "$command" | grep -qiE '(-X\s+POST|--method\s+POST|-XPOST)'; then
   deny "gh api POST to /pulls is equivalent to gh pr create and is blocked. Use vrg-submit-pr instead. All gh operations should use vrg-gh."
 else

--- a/hooks/scripts/block-raw-git-commit.sh
+++ b/hooks/scripts/block-raw-git-commit.sh
@@ -11,6 +11,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
 
 input=$(cat)
 cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
@@ -24,8 +26,9 @@ if command -v vrg-hook-guard &>/dev/null; then
 fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
 
-if echo "$command" | grep -qE '(^|[;&|]\s*)git\s+commit(\s|$)'; then
+if echo "$stripped" | grep -qE '(^|[;&|({]\s*)git\s+commit(\s|$)'; then
   jq -n '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/hooks/scripts/detect-deprecation-warnings.sh
+++ b/hooks/scripts/detect-deprecation-warnings.sh
@@ -13,16 +13,19 @@ cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib/managed-repo-check.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
 if ! is_managed_repo "$cwd"; then
   exit 0
 fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
 response=$(echo "$input" | jq -r '.tool_response // ""')
 
 # Only trigger after test commands
 is_test_command=false
-if echo "$command" | grep -qE '(^|[;&|]\s*)(pytest|cargo\s+test|go\s+test|bundle\s+exec\s+rspec|ruby\s+-e|rake\s+test|mvn\s+test|uv\s+run\s+pytest)(\s|$)'; then
+if echo "$stripped" | grep -qE '(^|[;&|({]\s*)(pytest|cargo\s+test|go\s+test|bundle\s+exec\s+rspec|ruby\s+-e|rake\s+test|mvn\s+test|uv\s+run\s+pytest)(\s|$)'; then
   is_test_command=true
 fi
 

--- a/hooks/scripts/enforce-host-container-split.sh
+++ b/hooks/scripts/enforce-host-container-split.sh
@@ -14,6 +14,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/managed-repo-check.sh"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/lib/host-container-tools.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/command-match.sh"
 
 input=$(cat)
 cwd=$(echo "$input" | jq -r '.tool_input.cwd // .cwd // "."')
@@ -23,10 +25,11 @@ if ! is_managed_repo "$cwd"; then
 fi
 
 command=$(echo "$input" | jq -r '.tool_input.command')
+stripped=$(strip_quoted_segments "$command")
 
 # Check for host tools wrapped in vrg-container-run -- (DENY)
 for tool in "${HOST_TOOLS[@]}"; do
-  if echo "$command" | grep -qE "(^|[;&|]\s*)vrg-container-run\s+--\s+$tool(\s|$)"; then
+  if echo "$stripped" | grep -qE "(^|[;&|({]\s*)vrg-container-run\s+--\s+$tool(\s|$)"; then
     jq -n --arg tool "$tool" '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
@@ -40,7 +43,7 @@ done
 
 # Check for container tools invoked directly (WARN)
 for tool in "${CONTAINER_TOOLS[@]}"; do
-  if echo "$command" | grep -qE "(^|[;&|]\s*)(vrg-container-run\s+--\s+)?$tool(\s|$)"; then
+  if echo "$stripped" | grep -qE "(^|[;&|({]\s*)(vrg-container-run\s+--\s+)?$tool(\s|$)"; then
     jq -n --arg tool "$tool" '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",

--- a/hooks/scripts/lib/command-match.sh
+++ b/hooks/scripts/lib/command-match.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# command-match.sh — shared quote-stripping helper for the plugin's
+# command matchers (#450).
+#
+# Tool-name matchers scan the Bash tool's raw command string. A tool
+# name at the start of a line inside a quoted multi-line argument
+# (vrg-commit --body, vrg-gh issue create --body) is
+# indistinguishable from a tool name in command position, producing
+# false denies. Stripping quoted spans first removes argument
+# content from the matcher's view; what remains is command
+# structure.
+#
+# Canonical rule and accepted gaps:
+#   docs/specs/2026-06-05-450-command-matcher-quoting-design.md §2
+#
+# This file is meant to be `source`d, not executed directly.
+#
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/command-match.sh"
+#   stripped=$(strip_quoted_segments "$command")
+#   if echo "$stripped" | grep -qE '(^|[;&|({]\s*)git\s+commit(\s|$)'; then
+
+# strip_quoted_segments <command-text>
+#
+# Prints the command text with single- and double-quoted spans
+# replaced by the placeholder "" in one left-to-right pass (leftmost
+# match wins, mirroring how the shell scans). Double-quoted spans
+# honor backslash escapes; single-quoted spans do not (shell
+# semantics). Multi-line spans are handled: jq's gsub operates on
+# the whole string, unlike line-oriented sed/grep. jq is already a
+# hard dependency of every hook script.
+#
+# Unbalanced quotes leave the remainder unstripped — a
+# false-positive (over-blocking) direction only; see spec §2.1.
+strip_quoted_segments() {
+	printf '%s' "$1" | jq -Rsr 'gsub("\"(\\\\.|[^\"\\\\])*\"|'\''[^'\'']*'\''"; "\"\"")'
+}

--- a/hooks/tests/command-match.test.sh
+++ b/hooks/tests/command-match.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# command-match.test.sh — table-driven tests for
+# strip_quoted_segments (#450).
+#
+# Encodes the stripping-relevant vectors of the canonical case
+# table: docs/specs/2026-06-05-450-command-matcher-quoting-design.md
+# §6.1 (rows 5, 7–10, 14) plus the empty command. bash
+# 3.2-compatible: parallel indexed arrays.
+#
+# Usage: bash hooks/tests/command-match.test.sh
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../scripts/lib/command-match.sh"
+
+NL='
+'
+
+T_NAME=(
+  "row 5: multi-line quoted body (#450 repro)"
+  "row 7: double-quoted span"
+  "row 8: single quotes nesting double quotes"
+  "row 9: escaped double quotes inside a span"
+  "row 10: unbalanced quote stays unstripped (separator in span)"
+  "row 14: unbalanced quote stays unstripped (no separator)"
+  "empty command"
+)
+T_INPUT=(
+  "vrg-commit --body \"line one${NL}git commit mentioned here\""
+  'echo "git commit"'
+  "echo 'say \"git commit\"'"
+  'echo "he said \"git commit\""'
+  'echo "; git commit'
+  'echo "git commit'
+  ""
+)
+T_EXPECT=(
+  'vrg-commit --body ""'
+  'echo ""'
+  'echo ""'
+  'echo ""'
+  'echo "; git commit'
+  'echo "git commit'
+  ""
+)
+
+pass=0
+fail=0
+i=0
+total=${#T_NAME[@]}
+
+while [ "$i" -lt "$total" ]; do
+  name="${T_NAME[$i]}"
+  got=$(strip_quoted_segments "${T_INPUT[$i]}")
+  expect="${T_EXPECT[$i]}"
+
+  if [ "$got" = "$expect" ]; then
+    echo "PASS [$i] $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL [$i] $name"
+    printf '       expected: %s\n' "$expect"
+    printf '       got:      %s\n' "$got"
+    fail=$((fail + 1))
+  fi
+  i=$((i + 1))
+done
+
+echo "----------------------------------------"
+echo "command-match: $pass passed, $fail failed, $total total"
+[ "$fail" -eq 0 ]

--- a/hooks/tests/command-matchers.test.sh
+++ b/hooks/tests/command-matchers.test.sh
@@ -78,6 +78,9 @@ T_NAME=(
   "protected: real commit at convention-repo root"
   "protected: non-commit with quoted commit prose (#450 over-blocking)"
   "protected: non-commit git operation"
+  "autoclose: forbidden linkage keyword"
+  "autoclose: Ref linkage allowed"
+  "autoclose: quoted body mentioning the rule (#450 shape)"
 )
 T_SCRIPT=(
   "block-raw-git-commit.sh"
@@ -109,6 +112,9 @@ T_SCRIPT=(
   "block-protected-branch-work.sh"
   "block-protected-branch-work.sh"
   "block-protected-branch-work.sh"
+  "block-autoclose-linkage.sh"
+  "block-autoclose-linkage.sh"
+  "block-autoclose-linkage.sh"
 )
 T_COMMAND=(
   'git commit -m x'
@@ -140,6 +146,9 @@ T_COMMAND=(
   'git commit -m x'
   "vrg-gh issue create --title t --body \"repro:${NL}git commit -m x was blocked\""
   'git push origin HEAD'
+  'vrg-submit-pr --issue 450 --linkage Fixes'
+  'vrg-submit-pr --issue 450 --linkage Ref'
+  "vrg-commit --type docs --scope x --message y --body \"policy reminder:${NL}vrg-submit-pr --linkage Fixes is forbidden\""
 )
 T_CWD=(
   "" "" "" "" "" "" "" "" "" "" "" ""
@@ -148,6 +157,7 @@ T_CWD=(
   "" "" "" ""
   "" "" ""
   "SCRATCH" "SCRATCH" "SCRATCH"
+  "" "" ""
 )
 T_RESPONSE=(
   "" "" "" "" "" "" "" "" "" "" "" ""
@@ -157,6 +167,7 @@ T_RESPONSE=(
   "DeprecationWarning: old API"
   "DeprecationWarning: old API"
   "2 passed"
+  "" "" ""
   "" "" ""
 )
 T_EXPECT=(
@@ -184,6 +195,9 @@ T_EXPECT=(
   "context"
   "allow"
   "context"
+  "allow"
+  "allow"
+  "deny"
   "allow"
   "allow"
   "deny"

--- a/hooks/tests/command-matchers.test.sh
+++ b/hooks/tests/command-matchers.test.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# command-matchers.test.sh — table-driven allow/deny tests for the
+# hook command matchers (#450).
+#
+# Encodes the canonical case table from
+# docs/specs/2026-06-05-450-command-matcher-quoting-design.md §6.1
+# (rows 11-12 excluded: the bash -c recheck lives in vrg-hook-guard,
+# not the plugin scripts), plus per-script cases. bash
+# 3.2-compatible: parallel indexed arrays.
+#
+# Usage: bash hooks/tests/command-matchers.test.sh
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$SCRIPT_DIR/../scripts"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+NL='
+'
+
+# block-raw-git-commit.sh delegates to vrg-hook-guard when it is on
+# PATH; mask it so the fallback regex path is what's tested.
+CLEAN_PATH=""
+old_ifs="$IFS"
+IFS=':'
+for dir in $PATH; do
+  if [ -x "$dir/vrg-hook-guard" ]; then
+    continue
+  fi
+  CLEAN_PATH="${CLEAN_PATH:+$CLEAN_PATH:}$dir"
+done
+IFS="$old_ifs"
+
+# Scratch managed repo that has adopted the worktree convention, for
+# block-protected-branch-work.sh rows. Using a scratch repo keeps
+# those rows deterministic whether this suite runs from the main
+# checkout or from inside a worktree.
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+git -C "$SCRATCH" init --quiet
+printf '[project]\n' > "$SCRATCH/vergil.toml"
+printf '.worktrees/\n' > "$SCRATCH/.gitignore"
+
+# Parallel arrays: one case per index.
+#   T_NAME     — label
+#   T_SCRIPT   — hook script under hooks/scripts/
+#   T_COMMAND  — tool_input.command payload value
+#   T_CWD      — payload cwd: "" = $ROOT, "SCRATCH" = $SCRATCH
+#   T_RESPONSE — tool_response payload value ("" = omit)
+#   T_EXPECT   — deny | allow | context
+T_NAME=(
+  "rgc row 1: plain invocation"
+  "rgc row 2: separator"
+  "rgc row 3: subshell separator"
+  "rgc row 4: brace-group separator"
+  "rgc row 5: multi-line quoted body (#450 repro)"
+  "rgc row 6: dot-git path"
+  "rgc row 7: double-quoted span"
+  "rgc row 8: single quotes nesting double quotes"
+  "rgc row 9: escaped double quotes"
+  "rgc row 10: unbalanced quote, separator in span (accepted FP)"
+  "rgc row 13: keyword position (accepted FN gap)"
+  "rgc row 14: unbalanced quote, no separator"
+)
+T_SCRIPT=(
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+  "block-raw-git-commit.sh"
+)
+T_COMMAND=(
+  'git commit -m x'
+  'cd foo && git commit'
+  'x=$(git commit -m x)'
+  '{ git commit -m x; }'
+  "vrg-commit --type docs --scope x --message y --body \"line one${NL}git commit mentioned here\""
+  'find . -path ./.git -prune'
+  'echo "git commit"'
+  "echo 'say \"git commit\"'"
+  'echo "he said \"git commit\""'
+  'echo "; git commit'
+  'if git commit; then :; fi'
+  'echo "git commit'
+)
+T_CWD=(
+  "" "" "" "" "" "" "" "" "" "" "" ""
+)
+T_RESPONSE=(
+  "" "" "" "" "" "" "" "" "" "" "" ""
+)
+T_EXPECT=(
+  "deny"
+  "deny"
+  "deny"
+  "deny"
+  "allow"
+  "allow"
+  "allow"
+  "allow"
+  "allow"
+  "deny"
+  "allow"
+  "allow"
+)
+
+pass=0
+fail=0
+i=0
+total=${#T_NAME[@]}
+
+while [ "$i" -lt "$total" ]; do
+  name="${T_NAME[$i]}"
+  script="${T_SCRIPT[$i]}"
+  cmd="${T_COMMAND[$i]}"
+  case_cwd="${T_CWD[$i]}"
+  resp="${T_RESPONSE[$i]}"
+  expect="${T_EXPECT[$i]}"
+
+  if [ "$case_cwd" = "SCRATCH" ]; then
+    case_cwd="$SCRATCH"
+  elif [ -z "$case_cwd" ]; then
+    case_cwd="$ROOT"
+  fi
+
+  payload=$(jq -n --arg cmd "$cmd" --arg cwd "$case_cwd" --arg resp "$resp" \
+    '{tool_input: {command: $cmd, cwd: $cwd}, cwd: $cwd}
+     + (if $resp == "" then {} else {tool_response: $resp} end)')
+
+  out=$(printf '%s' "$payload" \
+    | PATH="$CLEAN_PATH" bash "$SCRIPTS/$script" 2>&1) || true
+
+  verdict="allow"
+  if printf '%s' "$out" | grep -q '"permissionDecision": "deny"'; then
+    verdict="deny"
+  elif printf '%s' "$out" | grep -q '"additionalContext"'; then
+    verdict="context"
+  elif [ -n "$out" ]; then
+    # Any other output (errors, partial JSON) is a test failure.
+    verdict="error"
+  fi
+
+  if [ "$verdict" = "$expect" ]; then
+    echo "PASS [$i] $name"
+    pass=$((pass + 1))
+  else
+    echo "FAIL [$i] $name — expected $expect, got $verdict"
+    if [ -n "$out" ]; then
+      printf '%s\n' "$out" | head -5 | sed 's/^/       /'
+    fi
+    fail=$((fail + 1))
+  fi
+  i=$((i + 1))
+done
+
+echo "----------------------------------------"
+echo "command-matchers: $pass passed, $fail failed, $total total"
+[ "$fail" -eq 0 ]

--- a/hooks/tests/command-matchers.test.sh
+++ b/hooks/tests/command-matchers.test.sh
@@ -68,6 +68,10 @@ T_NAME=(
   "agent-merge: gh pr review --approve"
   "agent-merge: quoted body prose (#450 shape)"
   "agent-merge: gh api PUT merge"
+  "host-split: wrapped host tool denied"
+  "host-split: quoted body mentioning wrapped host tool (#450 shape)"
+  "host-split: bare container tool warns"
+  "host-split: quoted body mentioning container tool (#450 shape)"
 )
 T_SCRIPT=(
   "block-raw-git-commit.sh"
@@ -89,6 +93,10 @@ T_SCRIPT=(
   "block-agent-merge.sh"
   "block-agent-merge.sh"
   "block-agent-merge.sh"
+  "enforce-host-container-split.sh"
+  "enforce-host-container-split.sh"
+  "enforce-host-container-split.sh"
+  "enforce-host-container-split.sh"
 )
 T_COMMAND=(
   'git commit -m x'
@@ -110,15 +118,21 @@ T_COMMAND=(
   'gh pr review 5 --approve'
   "vrg-gh issue create --title t --body \"policy:${NL}gh pr merge 5 is forbidden\""
   'gh api repos/o/r/pulls/5/merge -X PUT'
+  'vrg-container-run -- git status'
+  "vrg-commit --type docs --scope x --message y --body \"never do this:${NL}vrg-container-run -- gh pr list\""
+  'shellcheck hooks/scripts/lib/command-match.sh'
+  "vrg-commit --type docs --scope x --message y --body \"container tools:${NL}shellcheck runs in the container\""
 )
 T_CWD=(
   "" "" "" "" "" "" "" "" "" "" "" ""
   "" "" ""
   "" "" "" ""
+  "" "" "" ""
 )
 T_RESPONSE=(
   "" "" "" "" "" "" "" "" "" "" "" ""
   "" "" ""
+  "" "" "" ""
   "" "" "" ""
 )
 T_EXPECT=(
@@ -141,6 +155,10 @@ T_EXPECT=(
   "deny"
   "allow"
   "deny"
+  "deny"
+  "allow"
+  "context"
+  "allow"
 )
 
 pass=0

--- a/hooks/tests/command-matchers.test.sh
+++ b/hooks/tests/command-matchers.test.sh
@@ -61,6 +61,9 @@ T_NAME=(
   "rgc row 10: unbalanced quote, separator in span (accepted FP)"
   "rgc row 13: keyword position (accepted FN gap)"
   "rgc row 14: unbalanced quote, no separator"
+  "pr-create: plain invocation"
+  "pr-create: quoted body prose (#450 shape)"
+  "pr-create: gh api POST to /pulls"
 )
 T_SCRIPT=(
   "block-raw-git-commit.sh"
@@ -75,6 +78,9 @@ T_SCRIPT=(
   "block-raw-git-commit.sh"
   "block-raw-git-commit.sh"
   "block-raw-git-commit.sh"
+  "block-raw-gh-pr-create.sh"
+  "block-raw-gh-pr-create.sh"
+  "block-raw-gh-pr-create.sh"
 )
 T_COMMAND=(
   'git commit -m x'
@@ -89,12 +95,17 @@ T_COMMAND=(
   'echo "; git commit'
   'if git commit; then :; fi'
   'echo "git commit'
+  'gh pr create --title x'
+  "vrg-commit --type docs --scope x --message y --body \"docs say${NL}gh pr create is blocked\""
+  'gh api repos/o/r/pulls -X POST'
 )
 T_CWD=(
   "" "" "" "" "" "" "" "" "" "" "" ""
+  "" "" ""
 )
 T_RESPONSE=(
   "" "" "" "" "" "" "" "" "" "" "" ""
+  "" "" ""
 )
 T_EXPECT=(
   "deny"
@@ -109,6 +120,9 @@ T_EXPECT=(
   "deny"
   "allow"
   "allow"
+  "deny"
+  "allow"
+  "deny"
 )
 
 pass=0

--- a/hooks/tests/command-matchers.test.sh
+++ b/hooks/tests/command-matchers.test.sh
@@ -64,6 +64,10 @@ T_NAME=(
   "pr-create: plain invocation"
   "pr-create: quoted body prose (#450 shape)"
   "pr-create: gh api POST to /pulls"
+  "agent-merge: gh pr merge"
+  "agent-merge: gh pr review --approve"
+  "agent-merge: quoted body prose (#450 shape)"
+  "agent-merge: gh api PUT merge"
 )
 T_SCRIPT=(
   "block-raw-git-commit.sh"
@@ -81,6 +85,10 @@ T_SCRIPT=(
   "block-raw-gh-pr-create.sh"
   "block-raw-gh-pr-create.sh"
   "block-raw-gh-pr-create.sh"
+  "block-agent-merge.sh"
+  "block-agent-merge.sh"
+  "block-agent-merge.sh"
+  "block-agent-merge.sh"
 )
 T_COMMAND=(
   'git commit -m x'
@@ -98,14 +106,20 @@ T_COMMAND=(
   'gh pr create --title x'
   "vrg-commit --type docs --scope x --message y --body \"docs say${NL}gh pr create is blocked\""
   'gh api repos/o/r/pulls -X POST'
+  'gh pr merge 5'
+  'gh pr review 5 --approve'
+  "vrg-gh issue create --title t --body \"policy:${NL}gh pr merge 5 is forbidden\""
+  'gh api repos/o/r/pulls/5/merge -X PUT'
 )
 T_CWD=(
   "" "" "" "" "" "" "" "" "" "" "" ""
   "" "" ""
+  "" "" "" ""
 )
 T_RESPONSE=(
   "" "" "" "" "" "" "" "" "" "" "" ""
   "" "" ""
+  "" "" "" ""
 )
 T_EXPECT=(
   "deny"
@@ -120,6 +134,10 @@ T_EXPECT=(
   "deny"
   "allow"
   "allow"
+  "deny"
+  "allow"
+  "deny"
+  "deny"
   "deny"
   "allow"
   "deny"

--- a/hooks/tests/command-matchers.test.sh
+++ b/hooks/tests/command-matchers.test.sh
@@ -81,6 +81,9 @@ T_NAME=(
   "autoclose: forbidden linkage keyword"
   "autoclose: Ref linkage allowed"
   "autoclose: quoted body mentioning the rule (#450 shape)"
+  "contents-api: write method denied"
+  "contents-api: GET allowed"
+  "contents-api: quoted body citing the blocked call (#450 shape)"
 )
 T_SCRIPT=(
   "block-raw-git-commit.sh"
@@ -115,6 +118,9 @@ T_SCRIPT=(
   "block-autoclose-linkage.sh"
   "block-autoclose-linkage.sh"
   "block-autoclose-linkage.sh"
+  "block-github-contents-api.sh"
+  "block-github-contents-api.sh"
+  "block-github-contents-api.sh"
 )
 T_COMMAND=(
   'git commit -m x'
@@ -149,6 +155,9 @@ T_COMMAND=(
   'vrg-submit-pr --issue 450 --linkage Fixes'
   'vrg-submit-pr --issue 450 --linkage Ref'
   "vrg-commit --type docs --scope x --message y --body \"policy reminder:${NL}vrg-submit-pr --linkage Fixes is forbidden\""
+  'gh api --method PUT repos/o/r/contents/f.md'
+  'gh api repos/o/r/contents/f.md'
+  "vrg-commit --type docs --scope x --message y --body \"blocked example:${NL}gh api --method PUT repos/o/r/contents/f.md\""
 )
 T_CWD=(
   "" "" "" "" "" "" "" "" "" "" "" ""
@@ -157,6 +166,7 @@ T_CWD=(
   "" "" "" ""
   "" "" ""
   "SCRATCH" "SCRATCH" "SCRATCH"
+  "" "" ""
   "" "" ""
 )
 T_RESPONSE=(
@@ -167,6 +177,7 @@ T_RESPONSE=(
   "DeprecationWarning: old API"
   "DeprecationWarning: old API"
   "2 passed"
+  "" "" ""
   "" "" ""
   "" "" ""
 )
@@ -195,6 +206,9 @@ T_EXPECT=(
   "context"
   "allow"
   "context"
+  "allow"
+  "allow"
+  "deny"
   "allow"
   "allow"
   "deny"

--- a/hooks/tests/command-matchers.test.sh
+++ b/hooks/tests/command-matchers.test.sh
@@ -72,6 +72,9 @@ T_NAME=(
   "host-split: quoted body mentioning wrapped host tool (#450 shape)"
   "host-split: bare container tool warns"
   "host-split: quoted body mentioning container tool (#450 shape)"
+  "deprecation: pytest with warning in output"
+  "deprecation: quoted body mentioning pytest (#450 shape)"
+  "deprecation: pytest with clean output"
 )
 T_SCRIPT=(
   "block-raw-git-commit.sh"
@@ -97,6 +100,9 @@ T_SCRIPT=(
   "enforce-host-container-split.sh"
   "enforce-host-container-split.sh"
   "enforce-host-container-split.sh"
+  "detect-deprecation-warnings.sh"
+  "detect-deprecation-warnings.sh"
+  "detect-deprecation-warnings.sh"
 )
 T_COMMAND=(
   'git commit -m x'
@@ -122,18 +128,25 @@ T_COMMAND=(
   "vrg-commit --type docs --scope x --message y --body \"never do this:${NL}vrg-container-run -- gh pr list\""
   'shellcheck hooks/scripts/lib/command-match.sh'
   "vrg-commit --type docs --scope x --message y --body \"container tools:${NL}shellcheck runs in the container\""
+  'pytest -q'
+  "vrg-commit --type docs --scope x --message y --body \"test notes:${NL}pytest emitted warnings\""
+  'pytest -q'
 )
 T_CWD=(
   "" "" "" "" "" "" "" "" "" "" "" ""
   "" "" ""
   "" "" "" ""
   "" "" "" ""
+  "" "" ""
 )
 T_RESPONSE=(
   "" "" "" "" "" "" "" "" "" "" "" ""
   "" "" ""
   "" "" "" ""
   "" "" "" ""
+  "DeprecationWarning: old API"
+  "DeprecationWarning: old API"
+  "2 passed"
 )
 T_EXPECT=(
   "deny"
@@ -158,6 +171,9 @@ T_EXPECT=(
   "deny"
   "allow"
   "context"
+  "allow"
+  "context"
+  "allow"
   "allow"
 )
 

--- a/hooks/tests/command-matchers.test.sh
+++ b/hooks/tests/command-matchers.test.sh
@@ -75,6 +75,9 @@ T_NAME=(
   "deprecation: pytest with warning in output"
   "deprecation: quoted body mentioning pytest (#450 shape)"
   "deprecation: pytest with clean output"
+  "protected: real commit at convention-repo root"
+  "protected: non-commit with quoted commit prose (#450 over-blocking)"
+  "protected: non-commit git operation"
 )
 T_SCRIPT=(
   "block-raw-git-commit.sh"
@@ -103,6 +106,9 @@ T_SCRIPT=(
   "detect-deprecation-warnings.sh"
   "detect-deprecation-warnings.sh"
   "detect-deprecation-warnings.sh"
+  "block-protected-branch-work.sh"
+  "block-protected-branch-work.sh"
+  "block-protected-branch-work.sh"
 )
 T_COMMAND=(
   'git commit -m x'
@@ -131,6 +137,9 @@ T_COMMAND=(
   'pytest -q'
   "vrg-commit --type docs --scope x --message y --body \"test notes:${NL}pytest emitted warnings\""
   'pytest -q'
+  'git commit -m x'
+  "vrg-gh issue create --title t --body \"repro:${NL}git commit -m x was blocked\""
+  'git push origin HEAD'
 )
 T_CWD=(
   "" "" "" "" "" "" "" "" "" "" "" ""
@@ -138,6 +147,7 @@ T_CWD=(
   "" "" "" ""
   "" "" "" ""
   "" "" ""
+  "SCRATCH" "SCRATCH" "SCRATCH"
 )
 T_RESPONSE=(
   "" "" "" "" "" "" "" "" "" "" "" ""
@@ -147,6 +157,7 @@ T_RESPONSE=(
   "DeprecationWarning: old API"
   "DeprecationWarning: old API"
   "2 passed"
+  "" "" ""
 )
 T_EXPECT=(
   "deny"
@@ -173,6 +184,9 @@ T_EXPECT=(
   "context"
   "allow"
   "context"
+  "allow"
+  "allow"
+  "deny"
   "allow"
   "allow"
 )

--- a/hooks/tests/command-matchers.test.sh
+++ b/hooks/tests/command-matchers.test.sh
@@ -84,6 +84,9 @@ T_NAME=(
   "contents-api: write method denied"
   "contents-api: GET allowed"
   "contents-api: quoted body citing the blocked call (#450 shape)"
+  "assoc: declare -A denied"
+  "assoc: indexed array allowed"
+  "assoc: quoted body citing the rule (#450 shape)"
 )
 T_SCRIPT=(
   "block-raw-git-commit.sh"
@@ -121,6 +124,9 @@ T_SCRIPT=(
   "block-github-contents-api.sh"
   "block-github-contents-api.sh"
   "block-github-contents-api.sh"
+  "block-associative-arrays.sh"
+  "block-associative-arrays.sh"
+  "block-associative-arrays.sh"
 )
 T_COMMAND=(
   'git commit -m x'
@@ -158,6 +164,9 @@ T_COMMAND=(
   'gh api --method PUT repos/o/r/contents/f.md'
   'gh api repos/o/r/contents/f.md'
   "vrg-commit --type docs --scope x --message y --body \"blocked example:${NL}gh api --method PUT repos/o/r/contents/f.md\""
+  'declare -A map'
+  'declare -a list'
+  "vrg-commit --type docs --scope x --message y --body \"bash policy:${NL}declare -A needs bash 4 and is blocked\""
 )
 T_CWD=(
   "" "" "" "" "" "" "" "" "" "" "" ""
@@ -166,6 +175,7 @@ T_CWD=(
   "" "" "" ""
   "" "" ""
   "SCRATCH" "SCRATCH" "SCRATCH"
+  "" "" ""
   "" "" ""
   "" "" ""
 )
@@ -177,6 +187,7 @@ T_RESPONSE=(
   "DeprecationWarning: old API"
   "DeprecationWarning: old API"
   "2 passed"
+  "" "" ""
   "" "" ""
   "" "" ""
   "" "" ""
@@ -206,6 +217,9 @@ T_EXPECT=(
   "context"
   "allow"
   "context"
+  "allow"
+  "allow"
+  "deny"
   "allow"
   "allow"
   "deny"

--- a/scripts/bin/validate-custom
+++ b/scripts/bin/validate-custom
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# validate-custom — repo-local validation hook discovered by
+# vrg-validate. Runs the hook test suites under hooks/tests/.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+status=0
+for t in "$ROOT"/hooks/tests/*.test.sh; do
+	echo "Running: $t"
+	bash "$t" || status=1
+done
+exit "$status"


### PR DESCRIPTION
# Pull Request

## Summary

- Quote-strip command text before tool-name matching across nine hook scripts; shared lib + canonical test vectors; vrg-hook-guard companion issue filed in vergil-tooling (#1443)

## Issue Linkage

- Ref #450

## Notes

- Spec: docs/specs/2026-06-05-450-command-matcher-quoting-design.md. Consumers need a plugin refresh after merge.