### PR TITLE
feat(skills): sequential dual-agent handshake with worktree-path hand-off and transparent loops

### DIFF
--- a/skills/issue-audit/SKILL.md
+++ b/skills/issue-audit/SKILL.md
@@ -10,20 +10,38 @@ Drive the AUDIT half of the local PR workflow. You stay **dumb**: the
 workflow. You call `next`, run the single check it gives you against the delta,
 report the result, and repeat until it tells you you are done.
 
+## Input
+
+You are launched with the **worktree path** the implement session handed off —
+e.g. `/vergil:issue-audit /abs/path/.worktrees/issue-1234-slug` — not an issue
+number. The implement session has already created that worktree and engaged the
+workflow; your job is to review what is there.
+
 ## Preflight
 
 1. Confirm you are the **AUDIT** agent: `vrg-whoami --mode` must print `audit`.
    If not, stop.
-2. You share the USER agent's worktree on the host mount. **You are read-only by
-   discipline:** never edit code, never commit, never push. You report verdicts
-   only through `vrg-pr-workflow`.
+2. **`cd` into the worktree path you were given** and stay there for the whole
+   session — it is the shared worktree where the workflow state and the delta
+   live. **You are read-only by discipline:** never edit code, never commit,
+   never push. You report verdicts only through `vrg-pr-workflow`.
+
+## Run it in the foreground — be transparent
+
+Drive this loop **inline, in the foreground**, narrating as you go: announce each
+check you receive, what you inspected, and the verdict you submit (with the
+reason). Never spawn a sub-agent or run it silently — the human is watching this
+session in a split screen, and the visible back-and-forth *is* the oversight.
+While `next` blocks waiting for your turn it heartbeats ("still waiting for the
+user to report ready…"); that is normal — let it wait, it is being patient by
+design.
 
 ## The loop
 
 Start (and re-enter) the loop with:
 
 ```bash
-vrg-pr-workflow next --issue <N>      # --issue required only on the first call
+vrg-pr-workflow next      # you are in the worktree; the issue is taken from the state
 ```
 
 `next` blocks until it is your turn, then prints **one** directive as JSON for a

--- a/skills/issue-implement/SKILL.md
+++ b/skills/issue-implement/SKILL.md
@@ -5,57 +5,72 @@ description: USER-identity skill — implement a GitHub issue by driving the vrg
 
 # Issue Implement
 
-Drive the USER half of the local PR workflow. You stay **dumb**: the
-`vrg-pr-workflow` oracle owns the workflow. You call `next`, do exactly what the
-one directive says, report your result through the verb it names, and repeat
-until it tells you you are done. You hold no workflow logic of your own.
+Drive the USER half of the local PR workflow. You **implement the issue
+directly**, then engage the `vrg-pr-workflow` oracle only to run the audit
+handshake — so the audit never sits idle on an empty worktree. Once you signal
+ready you stay **dumb**: do exactly what each directive says and report through
+the verb it names, until done.
+
+## Run it in the foreground — be transparent
+
+Do all of this **inline, in the foreground**, narrating as you go: what you are
+implementing, each oracle directive you receive, each audit finding, and how you
+address it. Never spawn a sub-agent or run the loop silently — the human is
+watching this session in a split screen next to the audit, and the visible
+back-and-forth *is* the oversight.
 
 ## Preflight
 
 1. Confirm you are the **USER** agent: `vrg-whoami --mode` must print `user`. If
    not, stop — this skill runs in the user-agent session.
-2. Be in the feature-branch worktree for this issue, not the repo root.
+2. **Create the worktree for this issue** from the repo root and work inside it
+   (pick a 2–4 token kebab slug):
 
-## The loop
+   ```bash
+   vrg-git worktree add -b feature/<N>-<slug> .worktrees/issue-<N>-<slug> origin/develop
+   cd .worktrees/issue-<N>-<slug>
+   ```
 
-Start (and re-enter) the loop with:
+## Implement, then hand off to the audit
 
-```bash
-vrg-pr-workflow next --issue <N>      # add --no-audit to skip the local audit
-```
+1. **Implement the issue** here with small `vrg-commit` commits. Validate until
+   green — `vrg-container-run -- vrg-validate` — fixing every failure and
+   re-running; **never** suppress a gate.
+2. **Hand off to the audit.** When the work is green and ready, give the human a
+   copy-pasteable line: *"Ready for audit — run
+   `/vergil:issue-audit <absolute-worktree-path>` in the audit window."*
+3. **Engage the oracle and signal ready:**
 
-`next` blocks until it is your turn, then prints **one** directive as JSON with
-a `do` (what to do) and a `then` (the verb to report with). Do the `do` exactly,
-run the `then` verb, then call `vrg-pr-workflow next` again. Repeat.
+   ```bash
+   vrg-pr-workflow next --issue <N>   # inits; heartbeats while waiting for the audit to join
+   ```
 
-- The CLI resolves your role from `vrg-whoami` — never pass `--as`.
-- `--issue <N>` is required only on the **first** `next` (it initializes the
-  workflow); omit it afterward.
-- `--no-audit` (solo mode) skips the *local* audit for small, high-confidence
-  work — quick one-liners, doc or config tweaks — trusting the CI gates as the
-  backstop. The PR-phase audit still runs after submission.
+   It returns an `implement` directive — you have already implemented, so go
+   straight to reporting ready:
 
-### Directives you will see
+   ```bash
+   vrg-pr-workflow report-ready --title "<conventional-commit title>" \
+     --summary "<one substantive sentence: what changed and why>" \
+     --notes "<reviewer-relevant notes>"
+   ```
 
-- **implement** — `then: { verb: "report-ready" }`. Implement the issue on the
-  branch with small `vrg-commit` commits. Validate until green
-  (`vrg-container-run -- vrg-validate`); fix every failure and re-run — **never**
-  suppress a gate. Then:
+   *Solo / no-audit:* for small, high-confidence work (one-liners, docs, config),
+   add `--no-audit` to that first `next`, skip the hand-off, and report ready —
+   the PR-phase audit still runs after submission.
 
-  ```bash
-  vrg-pr-workflow report-ready \
-    --title "<conventional-commit title>" \
-    --summary "<one substantive sentence: what changed and why>" \
-    --notes "<reviewer-relevant notes>"
-  ```
+## The review loop
 
-- **fix findings** — `then: { verb: "report-fixes" }`. The directive's
-  `findings` are the audit's requested changes. Address every one, validate
-  green, `vrg-commit`, then:
+Then loop: `vrg-pr-workflow next` → act on the directive → repeat.
+
+- **fix findings** — `then: { verb: "report-fixes" }`. Address every finding,
+  validate green, `vrg-commit`, then:
 
   ```bash
   vrg-pr-workflow report-fixes --note "<what you changed>"
   ```
+
+  When a finding is about the PR description itself, revise it on the same call
+  with `--summary` / `--notes` / `--title`.
 
 - **DONE** — `{ "done": true, "reason": "approved", ... }`. Tell the human:
   *"Approved — run `vrg-submit-pr` to open the PR."* Stop. Only the human opens


### PR DESCRIPTION
# Pull Request

## Summary

- Rework the issue-implement and issue-audit skills for the sequential, user-first dual-agent flow — issue-implement implements directly then engages the oracle only at the ready point (creating the worktree and emitting the /issue-audit <worktree-path> hand-off), and issue-audit takes that worktree path, cd's in, and runs with no issue number — and mandate foreground, narrated execution in both so the human watching the split screen sees the full back-and-forth.

## Issue Linkage

- Ref vergil-project/vergil-tooling#1572

## Notes

- Pairs with the vergil-tooling#1572 CLI change (patient, heartbeating waits and
audit-acks-from-state). The audit now starts only when there is something to
review, rather than racing a not-yet-created worktree and timing out. The
transparency requirement is explicit: neither agent runs in the background or
via sub-agents — the visible loop is the oversight model.