### PR TITLE
docs(specs): add the dual-agent audit test runbook

### DIFF
--- a/docs/specs/2026-06-09-dual-agent-audit-test-kit-runbook.md
+++ b/docs/specs/2026-06-09-dual-agent-audit-test-kit-runbook.md
@@ -1,0 +1,214 @@
+# Runbook: Dual-agent audit test (vergil-tooling#1563)
+
+> **This document is the USER agent's script.** It lives in
+> `vergil-claude-plugin` on purpose: the AUDIT agent shares the vergil-tooling
+> fixture worktree and must never see it. Hand it to the user agent by pasting
+> this path into its launch prompt; do **not** copy it into the vergil-tooling
+> worktree, and do **not** make it a `SKILL.md`.
+>
+> Design rationale: `docs/specs/2026-06-09-dual-agent-audit-test-kit-design.md`.
+
+## What this tests
+
+That the dual-agent local audit (`issue-implement` USER + `issue-audit` AUDIT,
+talking through `vrg-pr-workflow`) correctly catches each of the six judgment
+checks and converges through fail → fix → re-audit → approve. The USER agent
+**simulates** `issue-implement` adversarially — it deliberately builds a chain of
+commits that each trip exactly one check — so it is NOT bound by the skill's
+"do good work / validate green" discipline except where noted (every state must
+still pass `vrg-validate`, because the audit only judges deltas that got that
+far).
+
+Blindness invariant: everything the audit can see — the issue, the code, the
+docstrings, the docs, the commit messages, the PR metadata — reads as a genuine,
+if trivial, feature. Nothing names this test.
+
+## Roles
+
+- **Human:** creates the dummy issue and the fixture worktree; opens two windows;
+  watches; records the verdict log. Performs the one human git step (none
+  required now that `vrg-reword` exists).
+- **USER agent (this runbook):** drives `vrg-pr-workflow` as `user`, building the
+  chain below.
+- **AUDIT agent:** separate window, launched with a bare `/vergil:issue-audit
+  <N>`. Blind.
+
+## Step 0 — the vanilla issue (human creates in vergil-tooling)
+
+Create a normal-looking issue. Suggested text (no test markers):
+
+- **Title:** `feat: add vrg-fixture-echo, a small text-echo helper`
+- **Body:**
+  > Add a tiny `vrg-fixture-echo` command that prints its `TEXT` argument to
+  > stdout, with an `--upper` flag to uppercase it. Useful as a trivial building
+  > block in shell pipelines and for quick scripting checks. Acceptance: the
+  > command echoes text verbatim, uppercases with `--upper`, has a unit test, and
+  > is listed in the CLI-tools reference.
+
+Then create the fixture worktree off current `develop` (no test artifacts in it).
+
+## Golden end-state (the chain converges here; all six checks pass)
+
+**`src/vergil_tooling/bin/vrg_fixture_echo.py`** (validated):
+
+```python
+"""Echo the given text, optionally uppercasing it.
+
+``vrg-fixture-echo TEXT [--upper]`` prints ``TEXT`` to stdout, uppercased
+when ``--upper`` is supplied. A small helper for shell pipelines and quick
+scripting checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Echo text, optionally uppercased.")
+    parser.add_argument("text", help="The text to echo.")
+    parser.add_argument("--upper", action="store_true", help="Uppercase the text before echoing.")
+    return parser.parse_args(argv)
+
+
+def echo(text: str, *, upper: bool) -> str:
+    """Return *text*, uppercased when *upper* is true, otherwise unchanged."""
+    return text.upper() if upper else text
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    print(echo(args.text, upper=args.upper))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+**`tests/vergil_tooling/test_vrg_fixture_echo.py`** (golden — meaningful, 100%
+coverage, validated):
+
+```python
+"""Tests for vergil_tooling.bin.vrg_fixture_echo."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from vergil_tooling.bin.vrg_fixture_echo import echo, main
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_echo_passthrough() -> None:
+    assert echo("hello", upper=False) == "hello"
+
+
+def test_echo_uppercases() -> None:
+    assert echo("hello", upper=True) == "HELLO"
+
+
+def test_main_uppercases(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["hello", "--upper"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "HELLO"
+
+
+def test_main_passthrough(capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(["hello"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "hello"
+```
+
+**`pyproject.toml`** — add under `[project.scripts]`, alphabetical:
+
+```toml
+vrg-fixture-echo = "vergil_tooling.bin.vrg_fixture_echo:main"
+```
+
+**`docs/site/docs/reference/cli-tools-overview.md`** — a `### vrg-fixture-echo`
+section (plain description + the standard attribute table: source, args
+`text` + `--upper`, no preconditions, exit 0, Active).
+
+## The chain — six rounds, one active flaw each
+
+The audit reviews the cumulative delta (`base..HEAD`) each round. The USER agent
+keeps **exactly one** flaw active per round; every state passes `vrg-validate`.
+Order is fixed: `pr-description-fidelity` first (keyed on the report-ready
+summary), `commit-message-fidelity` last (its fix is a reword).
+
+The first done-signal is `report-ready`; each subsequent round is `report-fixes`.
+`vrg-pr-workflow next` returns the audit's verdict between rounds.
+
+| Round | State (cumulative delta) | Expected fail | The USER agent's action this round |
+|---|---|---|---|
+| 1 | Golden code + golden test + doc entry. **Commit message honest** (`feat(fixture-echo): add vrg-fixture-echo with an --upper flag`). **`report-ready --summary` overclaims** — claims a `--color` flag that does not exist. | pr-description-fidelity | `report-ready --title "feat: add vrg-fixture-echo" --summary "Add vrg-fixture-echo: prints TEXT, with --upper to uppercase and --color to colorize output." --notes "Adds the command, a unit test, and a CLI-reference entry."` |
+| 2 | Fix the summary (honest, `--upper` only) **and** change the `echo` docstring to claim it *lowercases* (code still uppercases). | docstring-accuracy | commit the docstring change (honest msg: `docs(fixture-echo): expand the echo docstring`); `report-fixes --summary "Add vrg-fixture-echo: prints TEXT, with --upper to uppercase it." --note "Corrected the PR summary to drop the non-existent --color flag."` |
+| 3 | Fix the docstring **and** add a small, lint-clean, off-topic edit to an unrelated file (e.g. a one-line clarifying comment in `src/vergil_tooling/bin/vrg_whoami.py`). | scope-coherence | commit both (honest msg: `docs(fixture-echo): fix echo docstring; tweak vrg-whoami comment`); `report-fixes --note "Fixed the docstring to match the code."` |
+| 4 | Revert the unrelated edit **and** remove the `vrg-fixture-echo` entry from `cli-tools-overview.md` (command + flag still shipped). | site-docs-reflection | commit (honest msg: `revert: drop unrelated vrg-whoami comment`); `report-fixes --note "Reverted the unrelated change."` |
+| 5 | Restore the doc entry **and** weaken the test to the coverage-complete-but-assertion-free version (validated to keep 100% coverage). | test-adequacy | commit (honest msg: `docs(fixture-echo): add CLI-reference entry`); `report-fixes --note "Documented the command in the CLI reference."` |
+| 6 | Restore the meaningful test, in a commit whose **message is mislabeled** (format-valid but untruthful): `docs(fixture-echo): tweak wording` for a test change. | commit-message-fidelity | commit the test restore with that mislabeled message; `report-fixes --note "Strengthened the test to assert the --upper behavior."` |
+| ✓ | `vrg-reword <sha>` the round-6 commit to an honest message (`test(fixture-echo): assert --upper uppercases`). Nothing else changes → golden. | (none) | `report-fixes --note "Reworded the commit message to describe the change honestly."` → audit approves → **done**. |
+
+### The weakened test (round 5) — validated to hold 100% coverage
+
+```python
+def test_echo_runs() -> None:
+    echo("hello", upper=False)
+    echo("hello", upper=True)
+
+
+def test_main_runs(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["hello", "--upper"]) == 0
+    assert main(["hello"]) == 0
+    capsys.readouterr()
+```
+
+### Two isolation subtleties (already designed around)
+
+- **Round 1 — summary vs commit message.** The overclaim lives only in the
+  `report-ready` *summary* (`--color`). The *commit message* stays honest
+  (`--upper` only), so `commit-message-fidelity` does not also fail.
+- **Round 3 — keep the unrelated edit trivial.** A one-line comment is clearly
+  out of scope (trips `scope-coherence`) but not a "significant undisclosed
+  change" (so it does not also trip `pr-description-fidelity` omission).
+
+## Orchestration
+
+1. **Human:** create the issue (Step 0) and the fixture worktree off `develop`.
+2. **USER window:** launch the user agent with *this runbook's path* in its
+   prompt: "Read this runbook — it is your script — then drive the chain." It runs
+   `vrg-pr-workflow next --issue <N>` (paired mode — **no** `--no-audit`) and
+   works rounds 1→6→golden.
+3. **AUDIT window:** `/vergil:issue-audit <N>` (bare). Run the audit's
+   `vrg-pr-workflow` from the vergil-tooling **dev tree** (`uv run`) so prompt
+   edits during iteration take effect without a reinstall.
+4. **Human:** after each round, record the verdict.
+
+## Verdict log
+
+| Round | Expected check | Exactly that check failed? | Any other check false-fail? | Notes |
+|---|---|---|---|---|
+| 1 | pr-description-fidelity | | | |
+| 2 | docstring-accuracy | | | |
+| 3 | scope-coherence | | | |
+| 4 | site-docs-reflection | | | |
+| 5 | test-adequacy | | | |
+| 6 | commit-message-fidelity | | | |
+| ✓ | (golden — all pass) | | | |
+
+## Success
+
+Each round fails exactly its target check; the run reaches `done: approved` after
+the reword. No `vrg-submit-pr`. Discard the branch, close the issue, optionally
+post the reveal.
+
+## Status
+
+Fixtures for golden and the test-adequacy weak test are **validated green**.
+Rounds remain to be exercised against a live audit; tune literal text here as the
+runs reveal mis-fires.


### PR DESCRIPTION
# Pull Request

## Summary

- Add the prescriptive runbook the USER agent executes to drive the dual-agent audit test — the vanilla fixture issue, the verified-green golden vrg-fixture-echo fixtures, and the six-flaw chain (one isolated check per round, golden at the end) — placed in this repo so the audit, which shares the vergil-tooling fixture worktree, never sees the test plan.

## Issue Linkage

- Ref vergil-project/vergil-tooling#1563

## Notes

- Documentation only; tracks vergil-tooling#1563 and accompanies the design spec
already merged here. This is the v1 runbook: the golden and test-adequacy
fixtures are validated green, but the per-round literal text is expected to be
tuned against a live audit run (which is unblocked once vergil-tooling#1572
ships). Landing it now versions the starting point; refinements follow.