### PR TITLE
docs(skills): document base-branch conflict resolution in issue-implement

### DIFF
--- a/skills/issue-implement/SKILL.md
+++ b/skills/issue-implement/SKILL.md
@@ -115,6 +115,27 @@ Then loop: `vrg-pr-workflow next` → act on the directive → repeat.
 If `next` (or any verb) **errors** — the audit escalated to the human, or the
 counterpart aborted — surface the message to the human and stop. Do not loop.
 
+## Resolving conflicts with the base branch
+
+If `develop` (the base) advances while your branch is in flight — whether
+mid-loop or after the PR is open — and your branch conflicts with it, resolve it
+as **routine**. No human sign-off is needed:
+
+1. `vrg-git fetch origin`
+2. `vrg-git rebase origin/develop` — resolve conflicts, keeping both sides where
+   each adds independent content. `ORIG_HEAD` is your undo
+   (`vrg-git reset --hard ORIG_HEAD`) if the rebase goes wrong.
+3. `vrg-container-run -- vrg-validate` until green — **never** suppress a gate.
+4. `vrg-git push --force-with-lease` to update the branch / PR.
+
+**Force-pushing to update your _own_ in-flight PR after a rebase is a normal,
+pre-authorized part of this workflow** — not an exceptional action requiring
+human approval. The general "never force-push without explicit request" rule
+guards shared/protected history; it does **not** apply to rebasing your own
+feature branch onto its base. Always use `--force-with-lease` (the safe form —
+it refuses to overwrite if the remote moved unexpectedly), never a bare
+`--force`.
+
 ## Notes
 
 - `vrg-submit-pr` reads the PR metadata from the state file the oracle wrote

--- a/skills/pr-watch/SKILL.md
+++ b/skills/pr-watch/SKILL.md
@@ -32,6 +32,12 @@ Loop:
 3. Otherwise **reconcile all three sources:** failing CI checks + audit review
    comments + human comments. Patch the code, `vrg-commit`, and push
    (`vrg-git push`). The new commit re-triggers CI and the audit's re-review.
+   - **Base-branch conflicts are routine here.** If the base (`develop`)
+     advanced and the PR now conflicts, rebase onto it and force-push — no human
+     sign-off needed: `vrg-git fetch origin`, `vrg-git rebase origin/develop`
+     (resolve, validate green), then `vrg-git push --force-with-lease`.
+     Force-pushing your _own_ in-flight PR after a rebase is pre-authorized; see
+     *Resolving conflicts with the base branch* in `issue-implement`.
 4. If you cannot get a check green or cannot satisfy a comment, **stop and ask
    the human** rather than thrashing.
 5. Loop with the updated `--since-sha` / `--since-reviews`.


### PR DESCRIPTION
# Pull Request

## Summary

- Document that rebasing an in-flight branch onto an advanced base and force-pushing your own PR with --force-with-lease is routine and pre-authorized, so a USER agent stops stalling on a normal rebase.

## Issue Linkage

- Ref #481

## Notes

- Adds a 'Resolving conflicts with the base branch' section to issue-implement and a matching pointer in the pr-watch USER half. Docs-only. Ref #481.