### PR TITLE
docs(skills): rewrite skill descriptions to lead with invocation triggers

### DIFF
--- a/docs/development/skills-architecture.md
+++ b/docs/development/skills-architecture.md
@@ -538,3 +538,45 @@ While executing the attack order:
 5. After each skill PR merges, this audit document is updated to
    mark the corresponding Part 2 entry's status as "done" with a
    pointer to the PR.
+
+## Authoring skill descriptions — the `description` is the trigger
+
+A skill's `description` frontmatter field is **the auto-invocation
+surface**. Claude Code matches a human's natural-language request
+against this string to decide whether to fire the skill — the body of
+the `SKILL.md` is never consulted for that decision. So the
+`description` must encode **when to invoke** the skill, not only
+**what the skill is**.
+
+**The anti-pattern** (what surfaced in
+[#489](https://github.com/vergil-project/vergil-claude-plugin/issues/489)):
+descriptions that lead with identity or mechanism —
+"USER-identity skill — …", "Identity-keyed post-PR skill — …",
+"Collaborative review of memory files — …". These read as
+"I am a specialist; do not pick me casually." A request phrased in
+plain language ("go implement this", "audit my memory") has nothing
+in the matchable surface to bind to, so the skill silently fails to
+fire and the agent hand-rolls the work instead — which, for
+`issue-implement`, strands the change with no sanctioned path to a PR.
+
+**The fix.** Write every `description` to:
+
+1. **Lead with the trigger.** Start with the action and *when* a human
+   would want it — "Use when/whenever the human asks to …" — before
+   any identity or mechanism framing.
+2. **Enumerate concrete verbal forms.** Quote 2–4 natural-language
+   phrasings a human actually uses ("implement #170", "go implement
+   this", "audit my memory"), including the bare slash-command form.
+   The router matches surface text; give it surface to match.
+3. **Encode the consequence of bypassing**, where bypassing is
+   harmful. `issue-implement`'s description states that `vrg-submit-pr`
+   is the *sole* PR path, precisely to discourage the freelance flow.
+4. **Keep identity/mechanism — but after the trigger.** Identity
+   ("Run as the vergil-audit agent"), the oracle it drives, and the
+   artifacts it writes still belong in the description; they just must
+   not be the *first* thing the router sees.
+
+When adding or editing a skill, sanity-check the description by asking:
+*would this fire on the plain-language request a human is most likely
+to make, or only on the exact slash command?* If only the latter, it
+has the gap above.

--- a/skills/deprecation-triage/SKILL.md
+++ b/skills/deprecation-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deprecation-triage
-description: Triage deprecation warnings into a consistent workflow with issue tracking and suppression rules.
+description: Triage a deprecation warning into a tracked decision. Use whenever a deprecation warning surfaces — the detect-deprecation-warnings PostToolUse hook fires, or the human points at a warning in test/CI/build output and asks how to handle it ("triage this deprecation", "what do we do about this warning"). Searches for an existing issue, decides defer-or-fix, and applies issue-tracking and suppression rules consistently.
 ---
 
 # Deprecation triage

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handoff
-description: Session-to-session continuity — capture work state before stopping (/handoff stop) or resume from a previous session (/handoff start).
+description: Capture or restore work state across sessions. Use when wrapping up and you want to preserve context for next time ("/handoff stop", "save my progress", "hand this off before I stop"), or when picking work back up ("/handoff start", "resume where I left off", "what was I working on"). Captures work state before stopping and restores it on resume.
 ---
 
 # Handoff

--- a/skills/issue-audit/SKILL.md
+++ b/skills/issue-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-audit
-description: AUDIT-identity skill — review a paired USER agent's delta read-only by running one judgment check per round-trip via vrg-pr-workflow, and report each verdict. Never edits code. Run as the vergil-audit agent.
+description: Review a paired USER agent's implementation as the AUDIT agent. Use whenever you are acting as the audit half of the dual-agent loop — typically launched from the issue-implement hand-off line ("run /vergil:issue-audit <worktree>"), or when the human asks you to audit or review the paired implementation. Reviews the USER agent's delta read-only, running one judgment check per round-trip via vrg-pr-workflow and reporting each verdict. Never edits code. Run as the vergil-audit agent.
 ---
 
 # Issue Audit

--- a/skills/issue-implement/SKILL.md
+++ b/skills/issue-implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-implement
-description: USER-identity skill — implement a GitHub issue by driving the vrg-pr-workflow oracle loop, then hand off to the human for PR submission. Runs without the local audit by default; pass `audit` to engage the local audit pair. Run as the vergil-user agent.
+description: Implement a GitHub issue end-to-end as the USER agent. Use whenever the human asks to implement, build, fix, or start work on an issue — "implement #170", "go implement this", "let's do issue N", "build out this issue" — with or without the slash command. Drives the vrg-pr-workflow oracle loop, which writes the .vergil/pr-workflow.json + pr-template.yml that vrg-submit-pr consumes. PR creation is funneled exclusively through vrg-submit-pr (vrg-gh pr create is banned), so hand-rolling the worktree/commit/PR flow instead leaves the work stranded with no path to a PR. Runs without the local audit by default; pass `audit` to engage the local audit pair. Run as the vergil-user agent.
 ---
 
 # Issue Implement

--- a/skills/memory-audit/SKILL.md
+++ b/skills/memory-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-audit
-description: Collaborative review of memory files — verify, assess staleness, and route each entry to the correct scope with human approval.
+description: Review memory files collaboratively with the human. Use when the human asks to audit, review, clean up, prune, or check memory ("audit my memory", "review MEMORY.md", "are these memories still accurate", "clean up memory"). Verifies each entry, assesses staleness, and routes it to the correct scope with human approval.
 ---
 
 # Memory Audit

--- a/skills/memory-init/SKILL.md
+++ b/skills/memory-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-init
-description: Initialize or update the memory directory with the human-approval policy header in MEMORY.md.
+description: Set up or refresh a project's memory directory. Use when the human asks to initialize, set up, bootstrap, or update memory ("init memory", "set up MEMORY.md", "add the memory policy header", "refresh the memory header"). Creates or updates MEMORY.md with the human-approval policy header.
 ---
 
 # Memory Init

--- a/skills/pr-watch/SKILL.md
+++ b/skills/pr-watch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-watch
-description: Identity-keyed post-PR skill emitted by vrg-submit-pr. As USER, monitor the PR and reconcile CI/audit/human feedback; as AUDIT, re-review and post the vergil-audit/approved check. Paste the same line into both agent sessions.
+description: Monitor and reconcile an open PR after vrg-submit-pr. Use whenever a PR has just been opened and needs watching — vrg-submit-pr emits the invocation line to paste into both agent sessions, or the human asks to watch, monitor, or babysit the PR through CI and review. As USER, monitor the PR and reconcile CI/audit/human feedback; as AUDIT, re-review and post the vergil-audit/approved check. Identity-keyed: paste the same line into both agent sessions.
 ---
 
 # PR watch

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: summarize
-description: Multi-mode summarization for decisions, operations, or stream-of-consciousness capture. Use when the user asks for a structured summary or invokes SOC capture.
+description: Produce a structured summary in decisions, operations, or stream-of-consciousness (SOC) mode. Use when the human asks for a structured summary, a decision or operations writeup, or SOC capture ("summarize this", "write up these decisions", "capture this as SOC", "log this operation"). SOC mode is the canonical voice→text capture for the fleet.
 ---
 
 # Summarize


### PR DESCRIPTION
# Pull Request

## Summary

- Rewrites all eight vergil skill descriptions to lead with a natural-language "use when" trigger so plain requests like "go implement this" reliably auto-fire the skill instead of being hand-rolled into a stranded branch.

## Issue Linkage

- Ref #489

## Notes

- Per issue #489. The description frontmatter is the auto-invocation surface; the prior descriptions led with identity/mechanism ("USER-identity skill — ...") and carried no trigger clause. All eight skills (issue-implement, issue-audit, pr-watch, handoff, deprecation-triage, memory-audit, memory-init, summarize) now lead with a trigger plus concrete verbal forms; issue-implement additionally states vrg-submit-pr is the sole PR path. Added an "Authoring skill descriptions" section to docs/development/skills-architecture.md (AC3). README quick-ref table and site index prose are separate human-facing content and intentionally left untouched. AC2 satisfied in-line (8 skills is not "many", no follow-up issues needed).