### PR TITLE
chore(publish): convert consumer-refresh from slash commands to CLI

### DIFF
--- a/vergil.toml
+++ b/vergil.toml
@@ -6,8 +6,11 @@ release-model = "tagged-release"
 
 [publish]
 consumer-refresh = """\
-/plugin marketplace update vergil-marketplace
-/reload-plugins
+# Refresh the marketplace metadata so the just-released version is visible,
+# then advance the installed plugin to it. The next Claude Code session start
+# loads the updated plugin, so no in-session reload step is needed.
+claude plugin marketplace update vergil-marketplace
+claude plugin update vergil@vergil-marketplace
 """
 
 [ci]


### PR DESCRIPTION
# Pull Request

## Summary

- Replaces the interactive slash commands in [publish].consumer-refresh with shell-executable CLI equivalents so the block can run under the vrg-release --install cascade.

## Issue Linkage

- Ref #494

## Notes

- The /reload-plugins step resolves to a concrete 'claude plugin update vergil@vergil-marketplace' — the proven lib/lima.py:update_plugins sequence — which advances the installed plugin to the just-released version. A fresh session loads the updated plugin on start, so no in-session reload is needed. Change is scoped to vergil.toml only; the README/CLAUDE.md in-session refresh docs intentionally keep slash commands (different context). Refs vergil-project/vergil-tooling#1643.