### PR TITLE
chore(config): pin own marketplace ref to develop for release compliance

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,8 @@
     "vergil-marketplace": {
       "source": {
         "source": "github",
-        "repo": "vergil-project/vergil-claude-plugin"
+        "repo": "vergil-project/vergil-claude-plugin",
+        "ref": "develop"
       }
     }
   },


### PR DESCRIPTION
# Pull Request

## Summary

- Add ref=develop to this repo's own .claude/settings.json marketplace source so the marketplace source repo satisfies the self-referential version-derived-ref audit, unblocking release.

## Issue Linkage

- Ref #501

## Notes

- One-line config fix. This repo is the marketplace source (ships .claude-plugin/marketplace.json), so its expected marketplace ref is develop, not a vergil.toml version. The ref was absent, failing the release-time local compliance audit (marketplace_ref expected develop, actual None). After the fix, vrg-github-repo-config audit reports local: compliant and vrg-validate is green.