### PR TITLE
docs(rename): update live references to vergil-containers (#506)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Example: `/vergil:issue-implement`.
 
 - [`vergil-tooling`](https://github.com/vergil-project/vergil-tooling)
   — Python CLIs, bash validators, git hooks (consumed via PATH).
-- [`vergil-docker`](https://github.com/vergil-project/vergil-docker)
+- [`vergil-containers`](https://github.com/vergil-project/vergil-containers)
   — Dev container images (`ghcr.io/vergil-project/dev-python`, `dev-go`,
   etc.) that `vrg-container-run` dispatches into.
 - [`vergil-actions`](https://github.com/vergil-project/vergil-actions)

--- a/docs/development/skills-architecture.md
+++ b/docs/development/skills-architecture.md
@@ -459,7 +459,7 @@ CI-green-wait per #85, worktree-aware finalization, pointer to
 `docs.yml`-trigger audit document mentioned in #84's
 acceptance, and the cross-ecosystem follow-up issues (per-repo
 deploy docs for `vergil-tooling`,
-`vergil-docker`, `vergil-actions`) mentioned in
+`vergil-containers`, `vergil-actions`) mentioned in
 issue 105's acceptance. Both are bigger than the audit's step 3
 scope and tracked separately.
 


### PR DESCRIPTION
# Pull Request

## Summary

- Update the live vergil-docker references (README repo link and the skills-architecture prose mention) to vergil-containers, coordinating with the vergil-docker repo rename.

## Issue Linkage

- Ref #506

## Notes

- Coordination follow-up for vergil-project/vergil-docker#328. MERGE IS GATED: hold until the GitHub repo rename (vergil-docker -> vergil-containers) lands. GitHub's old->new redirect keeps github.com links working in the interim. Reference-only; no functional changes; validation green. Published image paths unaffected (stable ghcr.io/vergil-project user namespace).