### PR TITLE
refactor(skills): simplify pr-watch to USER-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Shared workflow skills, invoked as `/vergil:<name>`.
 | Skill | Purpose |
 |---|---|
 | `issue-implement` | USER agent: implement an issue, validate to green, record the PR metadata, hand off to the human |
-| `pr-watch` | Post-PR loop — monitor/reconcile (USER) or re-review and gate (AUDIT) |
+| `pr-watch` | USER agent: monitor the open PR through CI/review and reconcile feedback until it is mergeable |
 | `deprecation-triage` | Triage deprecation warnings into tracking issues |
 | `summarize` | Decision / operation / stream-of-consciousness summaries |
 | `handoff` | Session-to-session continuity (capture/resume) |
@@ -213,9 +213,9 @@ the **human** opens the PR:
    validate to green, then record the PR metadata via
    `vrg-pr-workflow report-ready`.
 2. **You** run `vrg-submit-pr` to open the PR (agents cannot).
-3. Paste the emitted `/vergil:pr-watch <PR_URL>` into both the USER
-   and AUDIT agent sessions for the post-PR loop; the AUDIT identity
-   gates merge via the `vergil-audit/approved` check.
+3. Run the emitted `/vergil:pr-watch <PR_URL>` in the USER agent
+   session to monitor the PR through CI and review and reconcile
+   feedback until it is mergeable.
 
 Auto-merge is disabled fleet-wide; you review and merge
 feature/bugfix PRs manually.

--- a/docs/site/docs/skills/index.md
+++ b/docs/site/docs/skills/index.md
@@ -15,7 +15,7 @@ substantially change it.
 | Skill | Purpose | Status |
 |---|---|---|
 | [issue-implement](#issue-implement) | USER agent: implement an issue, validate to green, record the PR metadata, hand off to the human | Current (2.1) |
-| [pr-watch](#pr-watch) | Post-PR loop — monitor/reconcile (USER) or re-review and gate (AUDIT) | Current (2.1) |
+| [pr-watch](#pr-watch) | USER agent: monitor the open PR through CI/review and reconcile feedback until mergeable | Current (2.1) |
 | [deprecation-triage](#deprecation-triage) | Triage deprecation warnings into tracking issues | Current (reviewed 2026-04-23, no changes) |
 | [summarize](#summarize) | Decision / operation / stream-of-consciousness summaries; SOC mode is the canonical capture for the fleet | Current |
 
@@ -36,13 +36,13 @@ implementation through the point where the human opens the PR.
 
 ## pr-watch
 
-**What it does.** Identity-keyed post-PR loop, emitted by
-`vrg-submit-pr`. As USER, monitors the PR via `vrg-pr-await` and
-reconciles CI/audit/human feedback; as AUDIT, re-reviews and posts
-the `vergil-audit/approved` gate via `vrg-audit-approve`.
+**What it does.** USER-identity post-PR loop, emitted by
+`vrg-submit-pr`. Monitors the open PR via `vrg-pr-await` and
+reconciles failing CI checks and human review feedback, pushing
+fixes until the PR is mergeable.
 
-**When to use.** Paste the emitted one-liner into both agent
-sessions after the human opens the PR.
+**When to use.** Run the emitted `/vergil:pr-watch <PR_URL>` line in
+the USER agent session after the human opens the PR.
 
 **Status.** Current (Vergil 2.1).
 

--- a/skills/pr-watch/SKILL.md
+++ b/skills/pr-watch/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: pr-watch
-description: Monitor and reconcile an open PR after vrg-submit-pr. Use whenever a PR has just been opened and needs watching — vrg-submit-pr emits the invocation line to paste into both agent sessions, or the human asks to watch, monitor, or babysit the PR through CI and review. As USER, monitor the PR and reconcile CI/audit/human feedback; as AUDIT, re-review and post the vergil-audit/approved check. Identity-keyed: paste the same line into both agent sessions.
+description: Monitor and reconcile an open PR after vrg-submit-pr. Use whenever a PR has just been opened and needs watching — vrg-submit-pr emits the `/vergil:pr-watch <PR_URL>` line, or the human asks to watch, monitor, or babysit the PR through CI and review. Runs in the USER agent session: block on PR state with vrg-pr-await, reconcile failing CI and human review feedback, push fixes, and tell the human when the PR is mergeable.
 ---
 
 # PR watch
 
-Drive the post-PR loop (design spec §9). `vrg-submit-pr` prints
-`/vergil:pr-watch <PR_URL>`; paste it into **both** agent sessions. Read your
-own identity and run the matching half.
+Drive the post-PR loop. `vrg-submit-pr` prints `/vergil:pr-watch <PR_URL>`; run
+it in the USER agent session to monitor the open PR through CI and human review,
+reconcile feedback, and tell the human when the PR is ready to merge.
 
 ## `vrg-pr-await` is a blocking wait — run it in the foreground, don't poll
 
-Both halves below are driven by `vrg-pr-await`, which **blocks** until the PR
-state changes (a new commit, a new review, or a check result) and then prints the
+The loop is driven by `vrg-pr-await`, which **blocks** until the PR state
+changes (a new commit, a new review, or a check result) and then prints the
 current state as JSON. It is a single blocking call — not something to background
 or poll around:
 
@@ -20,17 +20,16 @@ or poll around:
   minutes; that wait *is* the call doing its job. Do not background it (`&` /
   `run_in_background`), do not `sleep`-and-retry, and do not poll GitHub
   separately in a loop.
-- **It returns once per state change.** Act on what it returns (reconcile, or
-  review), push your commit, then call `vrg-pr-await` again with updated
-  `--since-*` flags. The blocking call is the loop's clock — do not start other
-  work while it waits.
+- **It returns once per state change.** Act on what it returns (reconcile), push
+  your commit, then call `vrg-pr-await` again with updated `--since-*` flags. The
+  blocking call is the loop's clock — do not start other work while it waits.
 
-## Determine identity
+## Preflight
 
-Check `VRG_IDENTITY_MODE`: `user` → the **Monitor** half; `audit` → the
-**Review** half. If `human`, stop — this skill is for the agents.
+This skill runs in the **USER** agent session. Confirm with
+`vrg-whoami --mode` (`user`). If `human`, stop — this skill is for the agent.
 
-## USER half — Monitor & reconcile
+## Monitor & reconcile
 
 Loop:
 
@@ -42,12 +41,11 @@ Loop:
 
    (Omit the `--since-*` flags on the first call.) It prints PR state as JSON —
    parse the checks, reviews, and head SHA.
-2. **Stop condition:** all required checks are green **and** the
-   `vergil-audit/approved` check is success → tell the human the PR is
+2. **Stop condition:** all required checks are green → tell the human the PR is
    mergeable. Done.
-3. Otherwise **reconcile all three sources:** failing CI checks + audit review
-   comments + human comments. Patch the code, `vrg-commit`, and push
-   (`vrg-git push`). The new commit re-triggers CI and the audit's re-review.
+3. Otherwise **reconcile both sources:** failing CI checks + human review
+   comments. Patch the code, `vrg-commit`, and push (`vrg-git push`). The new
+   commit re-triggers CI.
    - **Base-branch conflicts are routine here.** If the base (`develop`)
      advanced and the PR now conflicts, rebase onto it and force-push — no human
      sign-off needed: `vrg-git fetch origin`, `vrg-git rebase origin/develop`
@@ -58,29 +56,7 @@ Loop:
    the human** rather than thrashing.
 5. Loop with the updated `--since-sha` / `--since-reviews`.
 
-## AUDIT half — Review & gate
-
-Loop:
-
-1. **Wait for a new commit:**
-
-   ```bash
-   vrg-pr-await <PR_URL> --since-sha <last-head-sha>
-   ```
-2. Re-review the delta of the new head commit (read-only — design §7.1).
-3. **Post the verdict on the PR:**
-   - Findings → post review comments with `vrg-gh`, then
-     `vrg-audit-approve <PR_URL> --conclusion failure` (the gate stays red).
-   - Clean → `vrg-audit-approve <PR_URL>` (conclusion `success` — the
-     `vergil-audit/approved` gate goes green).
-
-   `vrg-audit-approve` refuses to run as USER, so only this session can move the
-   gate.
-4. **Stop** when you have approved and all checks are green. For an ERROR that
-   needs the human, post `--conclusion failure` and alert them.
-
 ## Notes
 
-- **Per-commit gate:** the `vergil-audit/approved` check is bound to the head
-  SHA, so every USER push invalidates the prior approval and the AUDIT half must
-  re-post. That is by design — it forces re-review of new commits.
+- You never merge the PR. When the checks are green, the **human** reviews and
+  merges (auto-merge is disabled fleet-wide).


### PR DESCRIPTION
# Pull Request

## Summary

- Retire the dual-agent AUDIT half of pr-watch (re-review + vergil-audit/approved posting) now that the local audit agent is gone; keep the USER monitor-and-reconcile loop, drop the identity-keying and the gate stop-condition, and update the README and site skills index.

## Issue Linkage

- Ref #516

## Notes

- Non-breaking cleanup; not coordinated with any tooling release. vrg-audit-approve and the audit identity remain dormant infrastructure (no longer invoked by a skill). Historical design/spec docs and the audit-write-guard hook docs left untouched as record.